### PR TITLE
✨Feat: 로그인, 회원가입, JWT 기반 인증 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -55,6 +55,11 @@ dependencies {
 
 	// Security
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	//JWT
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.3'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.3'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.3'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/likelion/server/domain/user/entity/User.java
+++ b/src/main/java/com/likelion/server/domain/user/entity/User.java
@@ -1,0 +1,42 @@
+package com.likelion.server.domain.user.entity;
+
+import com.likelion.server.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 사용자 엔티티
+ * - 닉네임, 비밀번호, 생성일시
+ */
+@Entity
+@Getter
+@Setter
+@Builder
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor (access = AccessLevel.PROTECTED)
+@Table(name = "user")
+public class User extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true, length = 50)
+    private String nickname;  // 닉네임 (로그인 ID 역할)
+
+    @Column(nullable = false, length = 255)
+    private String password;  // 암호화된 비밀번호
+
+    private String refreshToken;
+
+    @Builder
+    public User(String nickname, String password) {
+        this.nickname = nickname;
+        this.password = password;
+    }
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
+    }
+
+}

--- a/src/main/java/com/likelion/server/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/likelion/server/domain/user/repository/UserRepository.java
@@ -1,0 +1,38 @@
+package com.likelion.server.domain.user.repository;
+
+import com.likelion.server.domain.user.entity.User;
+import jakarta.validation.constraints.NotBlank;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+/**
+ * 사용자 레포지토리
+ * - 닉네임 중복 확인 및 조회
+ */
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByNicknameAndPassword(
+            @NotBlank(message = "닉네임은 필수 입력 값입니다.")
+            String nickname,
+
+            @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+            String password
+    );
+
+    Optional<User> findByNickname(
+            @NotBlank(message = "닉네임은 필수 입력 값입니다.")
+            String nickname
+    );
+
+    boolean existsByNickname(
+            @NotBlank(message = "닉네임은 필수 입력 값입니다.")
+            String nickname
+    );
+
+    Optional<User> findByRefreshToken(
+            String refreshToken
+    );
+}

--- a/src/main/java/com/likelion/server/domain/user/service/UserService.java
+++ b/src/main/java/com/likelion/server/domain/user/service/UserService.java
@@ -1,0 +1,11 @@
+package com.likelion.server.domain.user.service;
+
+import com.likelion.server.domain.user.web.dto.*;
+
+import java.util.Map;
+
+public interface UserService {
+    UserResponse signup(SignupRequest request); // 회원가입
+
+    LoginResponse login(LoginRequest request); // 로그인
+}

--- a/src/main/java/com/likelion/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/likelion/server/domain/user/service/UserServiceImpl.java
@@ -1,0 +1,76 @@
+package com.likelion.server.domain.user.service;
+
+import com.likelion.server.domain.user.entity.User;
+import com.likelion.server.domain.user.repository.UserRepository;
+import com.likelion.server.domain.user.web.dto.*;
+import com.likelion.server.global.jwt.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 회원가입 / 로그인 비즈니스 로직
+ */
+@Service
+@RequiredArgsConstructor
+public class UserServiceImpl implements UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    //1. 회원가입
+    @Override
+    public UserResponse signup(SignupRequest request) {
+        // 중복 닉네임 검사
+        if (userRepository.existsByNickname(request.getNickname())) {
+            throw new IllegalArgumentException("이미 존재하는 닉네임입니다.");
+        }
+
+        // 비밀번호 일치 검사
+        if (!request.getPassword().equals(request.getPasswordCheck())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        // 유저 생성 및 저장
+        User user = User.builder()
+                .nickname(request.getNickname())
+                .password(passwordEncoder.encode(request.getPassword()))
+                .build();
+
+        userRepository.save(user);
+
+        return new UserResponse(user.getId(), user.getNickname());
+    }
+
+
+    //2. 로그인
+    @Override
+    public LoginResponse login(LoginRequest request) {
+        User user = userRepository.findByNickname(request.getNickname())
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 닉네임입니다."));
+
+        if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
+            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+        }
+
+        // Access / Refresh Token 생성
+        String accessToken = jwtTokenProvider.createAccessToken(user.getNickname());
+        String refreshToken = jwtTokenProvider.createRefreshToken();
+
+        // Refresh Token 저장
+        user.updateRefreshToken(refreshToken);
+        userRepository.save(user);
+
+        // DTO 형태로 반환
+        return new LoginResponse(
+                "로그인 성공",
+                accessToken,
+                refreshToken,
+                new UserResponse(user.getId(), user.getNickname())
+        );
+    }
+}

--- a/src/main/java/com/likelion/server/domain/user/web/controller/AuthController.java
+++ b/src/main/java/com/likelion/server/domain/user/web/controller/AuthController.java
@@ -1,0 +1,73 @@
+package com.likelion.server.domain.user.web.controller;
+
+import com.likelion.server.domain.user.entity.User;
+import com.likelion.server.domain.user.repository.UserRepository;
+import com.likelion.server.domain.user.service.UserService;
+import com.likelion.server.domain.user.web.dto.*;
+import com.likelion.server.global.jwt.JwtTokenProvider;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * 회원가입 / 로그인 API
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/auth")
+public class AuthController {
+
+    private final UserService userService;
+    private final UserRepository userRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    // 1. 회원가입
+    @PostMapping("/signup")
+    public ResponseEntity<Map<String, Object>> signup(@Valid @RequestBody SignupRequest request) {
+        UserResponse user = userService.signup(request);
+
+        Map<String, Object> response = new HashMap<>();
+        response.put("message", "회원가입이 완료되었습니다.");
+        response.put("user", user);
+        return ResponseEntity.ok(response);
+    }
+
+    // 2. 로그인
+    @PostMapping("/login")
+    public ResponseEntity<LoginResponse> login(@RequestBody LoginRequest request) {
+        LoginResponse response = userService.login(request);
+        return ResponseEntity.ok(response);
+    }
+
+
+    // 3. 토큰 재발급
+    @PostMapping("/refresh")
+    public ResponseEntity<RefreshResponse> refresh(@RequestBody Map<String, String> request) {
+        String refreshToken = request.get("refreshToken");
+
+        // DB에서 Refresh Token 일치하는 사용자 조회
+        User user = userRepository.findByRefreshToken(refreshToken)
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 Refresh Token"));
+
+        // Refresh Token 자체가 만료되었는지 검증
+        if (!jwtTokenProvider.validateToken(refreshToken)) {
+            throw new IllegalArgumentException("만료된 Refresh Token입니다. 다시 로그인하세요.");
+        }
+
+        // 새로운 Access Token 생성
+        String newAccessToken = jwtTokenProvider.createAccessToken(user.getNickname());
+
+        // 응답 반환
+        RefreshResponse response = new RefreshResponse(
+                "Access Token 재발급 성공",
+                newAccessToken
+        );
+
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/com/likelion/server/domain/user/web/dto/LoginRequest.java
+++ b/src/main/java/com/likelion/server/domain/user/web/dto/LoginRequest.java
@@ -1,0 +1,20 @@
+package com.likelion.server.domain.user.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 로그인 요청 DTO
+ */
+@Getter @Setter
+@NoArgsConstructor
+public class LoginRequest {
+
+    @NotBlank(message = "닉네임은 필수 입력 값입니다.")
+    private String nickname;
+
+    @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+    private String password;
+}

--- a/src/main/java/com/likelion/server/domain/user/web/dto/LoginResponse.java
+++ b/src/main/java/com/likelion/server/domain/user/web/dto/LoginResponse.java
@@ -1,0 +1,13 @@
+package com.likelion.server.domain.user.web.dto;
+
+import lombok.*;
+
+@Getter
+@AllArgsConstructor
+public class LoginResponse {
+    private String message;
+    private String accessToken;
+    private String refreshToken;
+    private UserResponse user;
+}
+

--- a/src/main/java/com/likelion/server/domain/user/web/dto/RefreshResponse.java
+++ b/src/main/java/com/likelion/server/domain/user/web/dto/RefreshResponse.java
@@ -1,0 +1,14 @@
+package com.likelion.server.domain.user.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * ✅ Access Token 재발급 응답 DTO
+ */
+@Getter
+@AllArgsConstructor
+public class RefreshResponse {
+    private String message;
+    private String accessToken;
+}

--- a/src/main/java/com/likelion/server/domain/user/web/dto/SignupRequest.java
+++ b/src/main/java/com/likelion/server/domain/user/web/dto/SignupRequest.java
@@ -1,0 +1,23 @@
+package com.likelion.server.domain.user.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+/**
+ * 회원가입 요청 DTO
+ */
+@Getter @Setter
+@NoArgsConstructor
+public class SignupRequest {
+
+    @NotBlank(message = "닉네임은 필수 입력 값입니다.")
+    private String nickname;
+
+    @NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+    private String password;
+
+    @NotBlank(message = "비밀번호 확인은 필수 입력 값입니다.")
+    private String passwordCheck;
+}

--- a/src/main/java/com/likelion/server/domain/user/web/dto/UserResponse.java
+++ b/src/main/java/com/likelion/server/domain/user/web/dto/UserResponse.java
@@ -1,0 +1,15 @@
+package com.likelion.server.domain.user.web.dto;
+
+import lombok.*;
+
+/**
+ * 회원가입 / 로그인 응답 DTO
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserResponse {
+    private Long id;
+    private String nickname;
+}

--- a/src/main/java/com/likelion/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/likelion/server/global/config/SecurityConfig.java
@@ -1,18 +1,35 @@
 package com.likelion.server.global.config;
 
+import com.likelion.server.global.jwt.*;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
 
 @Configuration
+@EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtUserDetailsService userDetailsService;
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    public AuthenticationManager authenticationManager(AuthenticationConfiguration configuration) throws Exception {
+        return configuration.getAuthenticationManager();
     }
 
     @Bean
@@ -22,8 +39,14 @@ public class SecurityConfig {
                 .csrf(AbstractHttpConfigurer::disable)
                 // HTTP 요청에 대한 접근 권한 설정
                 .authorizeHttpRequests(authorize -> authorize
-                        .requestMatchers("/**").permitAll()
+                        .requestMatchers("/**")
+                        .permitAll()
                         .anyRequest().authenticated()
+                )
+                // jwt 필터 추가
+                .addFilterBefore(
+                        new JwtAuthenticationFilter(jwtTokenProvider, userDetailsService),
+                        UsernamePasswordAuthenticationFilter.class
                 );
 
         return http.build();

--- a/src/main/java/com/likelion/server/global/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/likelion/server/global/jwt/JwtAuthenticationEntryPoint.java
@@ -1,0 +1,24 @@
+package com.likelion.server.global.jwt;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+/**
+ * 인증 실패 시 401 Unauthorized 반환
+ */
+@Component
+public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request,
+                         HttpServletResponse response,
+                         AuthenticationException authException) throws IOException {
+
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "인증이 필요합니다.");
+    }
+}

--- a/src/main/java/com/likelion/server/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/likelion/server/global/jwt/JwtAuthenticationFilter.java
@@ -1,0 +1,54 @@
+package com.likelion.server.global.jwt;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.*;
+import org.springframework.web.filter.OncePerRequestFilter;
+import java.io.IOException;
+
+/**
+ * JWT 인증 필터
+ * - 요청 헤더의 Authorization에서 JWT 토큰 추출
+ * - 유효성 검증 후 SecurityContext에 인증 저장
+ */
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtUserDetailsService userDetailsService;
+
+    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider,
+                                   JwtUserDetailsService userDetailsService) {
+        this.jwtTokenProvider = jwtTokenProvider;
+        this.userDetailsService = userDetailsService;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String header = request.getHeader("Authorization");
+
+        if (header != null && header.startsWith("Bearer ")) {
+            String token = header.substring(7);
+
+            if (jwtTokenProvider.validateToken(token)) {
+                String nickname = jwtTokenProvider.getNicknameFromToken(token);
+                UserDetails userDetails = userDetailsService.loadUserByUsername(nickname);
+
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(
+                                userDetails, null, userDetails.getAuthorities());
+
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/likelion/server/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/likelion/server/global/jwt/JwtTokenProvider.java
@@ -1,0 +1,72 @@
+package com.likelion.server.global.jwt;
+
+import io.jsonwebtoken.*;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.security.Key;
+import java.util.Date;
+
+/**
+ * JWT 토큰 생성 / 검증 유틸리티 (parserBuilder 없는 버전)
+ */
+@Component
+public class JwtTokenProvider {
+
+    // 비밀키 (256bit 이상 권장)
+    private static final String SECRET_KEY = "QROOM_SECRET_KEY_QROOM_SECRET_KEY_1234567891011";
+    // 토큰 유효기간
+    private static final long ACCESS_TOKEN_EXPIRATION = 1000 * 60 * 60;       // 1시간
+    private static final long REFRESH_TOKEN_EXPIRATION = 1000 * 60 * 60 * 24 * 7; // 7일
+
+    private final Key key = Keys.hmacShaKeyFor(SECRET_KEY.getBytes());
+
+    /** 1. 토큰 생성 */
+    /** Access Token */
+    public String createAccessToken(String nickname) {
+        Date now = new Date();
+        return Jwts.builder()
+                .subject(nickname)
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + ACCESS_TOKEN_EXPIRATION))
+                .signWith(key)
+                .compact();
+    }
+
+    /** Refresh Token */
+    public String createRefreshToken() {
+        Date now = new Date();
+        return Jwts.builder()
+                .issuedAt(now)
+                .expiration(new Date(now.getTime() + REFRESH_TOKEN_EXPIRATION))
+                .signWith(key)
+                .compact();
+    }
+
+    /** 2. 토큰에서 닉네임(subject) 추출 */
+    public String getNicknameFromToken(String token) {
+        return Jwts.parser()
+                .verifyWith((SecretKey) key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload()
+                .getSubject();
+    }
+
+    /** 3. 토큰 유효성 검증 */
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser()
+                    .verifyWith((SecretKey) key)
+                    .build()
+                    .parseSignedClaims(token);
+            return true;
+        } catch (io.jsonwebtoken.ExpiredJwtException e) {
+            System.out.println("❌ JWT 만료됨");
+        } catch (Exception e) {
+            System.out.println("❌ JWT 검증 실패: " + e.getMessage());
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/likelion/server/global/jwt/JwtUserDetailsService.java
+++ b/src/main/java/com/likelion/server/global/jwt/JwtUserDetailsService.java
@@ -1,0 +1,29 @@
+package com.likelion.server.global.jwt;
+
+import com.likelion.server.domain.user.entity.User;
+import com.likelion.server.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.*;
+import org.springframework.stereotype.Service;
+
+/**
+ * JWT 인증용 사용자 정보 로드 서비스
+ */
+@Service
+@RequiredArgsConstructor
+public class JwtUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String nickname) throws UsernameNotFoundException {
+        User user = userRepository.findByNickname(nickname)
+                .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + nickname));
+
+        return org.springframework.security.core.userdetails.User.builder()
+                .username(user.getNickname())
+                .password(user.getPassword())
+                .authorities("USER")
+                .build();
+    }
+}


### PR DESCRIPTION
## 🔍 관련 이슈
- close #8 

<br>

## ✅ 작업 분류
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 수정
- [x] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
- [x] user domain 구조 설계
- [x] JWT 설정
- [x] 회원가입 API (auth/signup)
- [x] 로그인 API (auth/login)
- [x] access 토큰 재발급 (auth/refresh)
- [x] API 테스트 및 명세서 수정


<br>

## 👥 전달사항
1. User 도메인 구조를 변경하였습니다.
2. User 테이블을 생성하였습니다.
3. 기존 User 테이블에서 refreshToken 필드를 추가했습니다.
4. BuildGradle 에 JWT 의존성이 추가되었습니다.
5. SecurityConfig 에 JWT 관련 필터가 추가되었습니다.

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
1. 회원가입 (auth/signup)
<img width="725" height="664" alt="image" src="https://github.com/user-attachments/assets/da769f72-785d-40b4-8abf-a7f48b473741" />

2. 로그인 (auth/login)
<img width="887" height="804" alt="image" src="https://github.com/user-attachments/assets/af7d93b1-c1e7-461f-92f4-7228a95cfdba" />

3. 토큰 재발급 (auth/refresh)
<img width="867" height="713" alt="image" src="https://github.com/user-attachments/assets/200337d1-afce-4b40-84a2-fae81dfc4060" />
