### PR TITLE
✨Feat: 그룹 생성 API 구현

### DIFF
--- a/src/main/java/com/likelion/server/domain/group/controller/GroupController.java
+++ b/src/main/java/com/likelion/server/domain/group/controller/GroupController.java
@@ -1,0 +1,32 @@
+package com.likelion.server.domain.group.controller;
+
+import com.likelion.server.domain.group.service.GroupService;
+import com.likelion.server.domain.group.web.dto.CreateGroupRequest;
+import com.likelion.server.domain.group.web.dto.CreateGroupResponse;
+import com.likelion.server.global.response.SuccessResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping
+public class GroupController {
+
+    private final GroupService groupService;
+
+    // 새 그룹 생성
+    @PostMapping("/group/new")
+    public SuccessResponse<CreateGroupResponse> createGroup(
+            @AuthenticationPrincipal(expression = "id") Long userId,
+            @RequestBody @Valid CreateGroupRequest createGroupRequest
+    ) {
+        CreateGroupResponse data = groupService.create(userId, createGroupRequest);
+        return SuccessResponse.created(data);
+    }
+}

--- a/src/main/java/com/likelion/server/domain/group/entity/Group.java
+++ b/src/main/java/com/likelion/server/domain/group/entity/Group.java
@@ -16,15 +16,15 @@ public class Group extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, length = 100)
+    @Column(nullable = false, length = 10)
     private String name;
 
+    @Column(unique = true, length = 6)
     private String groupCode;   // 초대 코드
+
     private String examDate;    // 예정 시험일 (문자열로 관리 가능)
+
+    @Column(nullable = false)
     private Integer imageNum;
 
-    public Group(String name, String groupCode) {
-        this.name = name;
-        this.groupCode = groupCode;
-    }
 }

--- a/src/main/java/com/likelion/server/domain/group/entity/Member.java
+++ b/src/main/java/com/likelion/server/domain/group/entity/Member.java
@@ -10,7 +10,7 @@ import lombok.*;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-@Table(name = "member")
+@Table(name = "member", uniqueConstraints = @UniqueConstraint(columnNames = {"group_id", "user_id"}))
 public class Member {
 
     @Id
@@ -29,4 +29,9 @@ public class Member {
     private Role role;
 
 
+    public Member(Group groupId, User userId, Role role) {
+        this.group = groupId;
+        this.user = userId;
+        this.role = role;
+    }
 }

--- a/src/main/java/com/likelion/server/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/likelion/server/domain/group/repository/GroupMemberRepository.java
@@ -1,0 +1,6 @@
+package com.likelion.server.domain.group.repository;
+
+import com.likelion.server.domain.group.entity.Member;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GroupMemberRepository extends JpaRepository<Member, Long> {}

--- a/src/main/java/com/likelion/server/domain/group/repository/StudyGroupRepository.java
+++ b/src/main/java/com/likelion/server/domain/group/repository/StudyGroupRepository.java
@@ -3,4 +3,6 @@ package com.likelion.server.domain.group.repository;
 import com.likelion.server.domain.group.entity.Group;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface StudyGroupRepository extends JpaRepository<Group, Long> {}
+public interface StudyGroupRepository extends JpaRepository<Group, Long> {
+    boolean existsByGroupCode(String groupCode);
+}

--- a/src/main/java/com/likelion/server/domain/group/repository/StudyGroupRepository.java
+++ b/src/main/java/com/likelion/server/domain/group/repository/StudyGroupRepository.java
@@ -1,0 +1,6 @@
+package com.likelion.server.domain.group.repository;
+
+import com.likelion.server.domain.group.entity.Group;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StudyGroupRepository extends JpaRepository<Group, Long> {}

--- a/src/main/java/com/likelion/server/domain/group/service/GroupService.java
+++ b/src/main/java/com/likelion/server/domain/group/service/GroupService.java
@@ -1,0 +1,8 @@
+package com.likelion.server.domain.group.service;
+
+import com.likelion.server.domain.group.web.dto.CreateGroupRequest;
+import com.likelion.server.domain.group.web.dto.CreateGroupResponse;
+
+public interface GroupService {
+    CreateGroupResponse create(Long userId, CreateGroupRequest req);
+}

--- a/src/main/java/com/likelion/server/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/com/likelion/server/domain/group/service/GroupServiceImpl.java
@@ -1,0 +1,87 @@
+package com.likelion.server.domain.group.service;
+
+import com.likelion.server.domain.group.entity.Group;
+import com.likelion.server.domain.group.entity.Member;
+import com.likelion.server.domain.group.entity.enums.Role;
+import com.likelion.server.domain.group.repository.GroupMemberRepository;
+import com.likelion.server.domain.group.repository.StudyGroupRepository;
+import com.likelion.server.domain.group.web.dto.CreateGroupRequest;
+import com.likelion.server.domain.group.web.dto.CreateGroupResponse;
+import com.likelion.server.domain.user.entity.User;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.security.SecureRandom;
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class GroupServiceImpl implements GroupService {
+
+    private final StudyGroupRepository studyGroupRepository;
+    private final GroupMemberRepository groupMemberRepository;
+    private final EntityManager em;
+
+    private static final char[] CODE_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".toCharArray();
+    private static final SecureRandom RND = new SecureRandom();
+
+    @Override
+    public CreateGroupResponse create(Long userId, CreateGroupRequest createGroupRequest) {
+
+        // examDate 파싱
+        LocalDate examDate = null;
+        if (createGroupRequest.examDate() != null && !createGroupRequest.examDate().isBlank()) {
+            examDate = LocalDate.parse(createGroupRequest.examDate()); // yyyy-MM-dd
+        }
+
+        // GroupCode 생성
+        String code = generateUniqueCode(6);
+
+        // Group 생성
+        Group group = Group.builder()
+                .name(createGroupRequest.name())
+                .examDate(String.valueOf(examDate))
+                .imageNum(createGroupRequest.imageNum())
+                .groupCode(code)
+                .build();
+        Group saveGroup = studyGroupRepository.save(group);
+
+        // Group leader 등록
+        Member leader = new Member(
+                em.getReference(Group.class, saveGroup.getId()),
+                em.getReference(User.class, userId),
+                Role.LEADER
+        );
+        groupMemberRepository.save(leader);
+
+        // return
+        return new CreateGroupResponse(
+                saveGroup.getId(),
+                saveGroup.getName(),
+                saveGroup.getExamDate() != null ? saveGroup.getExamDate().toString() : null,
+                saveGroup.getGroupCode(),
+                saveGroup.getImageNum()
+        );
+    }
+
+    private String generateUniqueCode(int length) {
+        String code;
+        int attempts = 0;
+        do {
+            code = randomCode(length);
+            if (++attempts > 20) {
+                throw new IllegalStateException("그룹 코드 생성에 실패했습니다. 다시 시도해주세요.");
+            }
+        } while (studyGroupRepository.existsByGroupCode(code));
+        return code;
+    }
+
+    private String randomCode(int length) {
+        StringBuilder sb = new StringBuilder(length);
+        for (int i = 0; i < length; i++) sb.append(CODE_CHARS[RND.nextInt(CODE_CHARS.length)]);
+        return sb.toString();
+    }
+}

--- a/src/main/java/com/likelion/server/domain/group/web/dto/CreateGroupRequest.java
+++ b/src/main/java/com/likelion/server/domain/group/web/dto/CreateGroupRequest.java
@@ -1,0 +1,13 @@
+package com.likelion.server.domain.group.web.dto;
+
+import jakarta.validation.constraints.*;
+
+public record CreateGroupRequest(
+        @NotBlank @Size(min = 1, max = 10)
+        String name,
+
+        String examDate,
+
+        @NotNull @Min(1) @Max(10)
+        Integer imageNum
+) {}

--- a/src/main/java/com/likelion/server/domain/group/web/dto/CreateGroupResponse.java
+++ b/src/main/java/com/likelion/server/domain/group/web/dto/CreateGroupResponse.java
@@ -1,0 +1,9 @@
+package com.likelion.server.domain.group.web.dto;
+
+public record CreateGroupResponse(
+        Long id,
+        String groupName,
+        String examDate,   // yyyy-MM-dd or null
+        String groupCode,
+        Integer imageNum
+) { }

--- a/src/main/java/com/likelion/server/global/config/SchedulerConfig.java
+++ b/src/main/java/com/likelion/server/global/config/SchedulerConfig.java
@@ -1,8 +1,0 @@
-package com.likelion.server.global.config;
-
-import org.springframework.context.annotation.Configuration;
-import org.springframework.scheduling.annotation.EnableScheduling;
-
-@Configuration
-@EnableScheduling
-public class SchedulerConfig { }

--- a/src/main/java/com/likelion/server/global/jwt/JwtUserDetailsService.java
+++ b/src/main/java/com/likelion/server/global/jwt/JwtUserDetailsService.java
@@ -2,9 +2,13 @@ package com.likelion.server.global.jwt;
 
 import com.likelion.server.domain.user.entity.User;
 import com.likelion.server.domain.user.repository.UserRepository;
+import com.likelion.server.global.security.CustomUserDetails;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.*;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 /**
  * JWT 인증용 사용자 정보 로드 서비스
@@ -20,10 +24,9 @@ public class JwtUserDetailsService implements UserDetailsService {
         User user = userRepository.findByNickname(nickname)
                 .orElseThrow(() -> new UsernameNotFoundException("사용자를 찾을 수 없습니다: " + nickname));
 
-        return org.springframework.security.core.userdetails.User.builder()
-                .username(user.getNickname())
-                .password(user.getPassword())
-                .authorities("USER")
-                .build();
+        List<SimpleGrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_USER"));
+
+        // 기본 UserDetails 대신 CustomUserDetails 반환 (id 포함)
+        return new CustomUserDetails(user.getId(), user.getNickname(), user.getPassword(), authorities);
     }
 }

--- a/src/main/java/com/likelion/server/global/security/CustomUserDetails.java
+++ b/src/main/java/com/likelion/server/global/security/CustomUserDetails.java
@@ -1,0 +1,31 @@
+package com.likelion.server.global.security;
+
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+@Getter
+public class CustomUserDetails implements UserDetails {
+
+    private final Long id;
+    private final String username;
+    private final String password;
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    private final boolean accountNonExpired = true;
+    private final boolean accountNonLocked = true;
+    private final boolean credentialsNonExpired = true;
+    private final boolean enabled = true;
+
+    public CustomUserDetails(Long id,
+                             String username,
+                             String password,
+                             Collection<? extends GrantedAuthority> authorities) {
+        this.id = id;
+        this.username = username;
+        this.password = password;
+        this.authorities = authorities;
+    }
+}


### PR DESCRIPTION
## 🔍 관련 이슈
<!--
- close #123
-->
- close #13 

<br>

## ✅ 작업 분류
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
1. GroupService/Repository에 그룹 생성 로직을 구현했습니다.
2. POST /api/groups 엔드포인트를 추가하고 요청/응답 DTO를 작성했습니다.
3. JWT 인증을 연동해 토큰의 사용자 정보를 확인하고, 그 사용자가 그룹 리더가 되도록 매핑했습니다.
4. 커스텀 UserDetails를 추가하고, JwtUserDetailsService 로직을 수정해 인증 시 사용자 정보가 올바르게 매핑되도록 했습니다.

<br>

## 👥 전달사항


<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
<img width="753" height="664" alt="image" src="https://github.com/user-attachments/assets/0abcd87f-4a4b-4234-9c22-d00092a9cf7c" />
