### PR TITLE
✨Feat: 그룹 입장 API 구현

### DIFF
--- a/src/main/java/com/likelion/server/domain/group/exception/AlreadyGroupMemberException.java
+++ b/src/main/java/com/likelion/server/domain/group/exception/AlreadyGroupMemberException.java
@@ -1,0 +1,9 @@
+package com.likelion.server.domain.group.exception;
+
+import com.likelion.server.global.exception.BaseException;
+
+public class AlreadyGroupMemberException extends BaseException {
+    public AlreadyGroupMemberException() {
+        super(GroupErrorCode.GROUP_409_ALREADY_MEMBER);
+    }
+}

--- a/src/main/java/com/likelion/server/domain/group/exception/GroupErrorCode.java
+++ b/src/main/java/com/likelion/server/domain/group/exception/GroupErrorCode.java
@@ -1,0 +1,19 @@
+package com.likelion.server.domain.group.exception;
+
+import com.likelion.server.global.response.code.BaseResponseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import static com.likelion.server.global.constant.StaticValue.CONFLICT;
+import static com.likelion.server.global.constant.StaticValue.NOT_FOUND;
+
+@Getter
+@AllArgsConstructor
+public enum GroupErrorCode implements BaseResponseCode {
+    GROUP_404_NOT_FOUND_BY_CODE("GROUP_404_NOT_FOUND_BY_CODE", NOT_FOUND, "존재하지 않는 그룹 코드입니다."),
+    GROUP_409_ALREADY_MEMBER("GROUP_409_ALREADY_MEMBER", CONFLICT, "이미 가입된 그룹입니다.");
+
+    private final String code;
+    private final int httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/likelion/server/domain/group/exception/GroupNotFoundException.java
+++ b/src/main/java/com/likelion/server/domain/group/exception/GroupNotFoundException.java
@@ -1,0 +1,9 @@
+package com.likelion.server.domain.group.exception;
+
+import com.likelion.server.global.exception.BaseException;
+
+public class GroupNotFoundException extends BaseException {
+    public GroupNotFoundException() {
+        super(GroupErrorCode.GROUP_404_NOT_FOUND_BY_CODE);
+    }
+}

--- a/src/main/java/com/likelion/server/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/likelion/server/domain/group/repository/GroupMemberRepository.java
@@ -3,4 +3,6 @@ package com.likelion.server.domain.group.repository;
 import com.likelion.server.domain.group.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface GroupMemberRepository extends JpaRepository<Member, Long> {}
+public interface GroupMemberRepository extends JpaRepository<Member, Long> {
+    boolean existsByGroupIdAndUserId(Long groupId, Long userId);
+}

--- a/src/main/java/com/likelion/server/domain/group/repository/StudyGroupRepository.java
+++ b/src/main/java/com/likelion/server/domain/group/repository/StudyGroupRepository.java
@@ -3,6 +3,9 @@ package com.likelion.server.domain.group.repository;
 import com.likelion.server.domain.group.entity.Group;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface StudyGroupRepository extends JpaRepository<Group, Long> {
     boolean existsByGroupCode(String groupCode);
+    Group findByGroupCode(String groupCode);
 }

--- a/src/main/java/com/likelion/server/domain/group/service/GroupService.java
+++ b/src/main/java/com/likelion/server/domain/group/service/GroupService.java
@@ -2,7 +2,9 @@ package com.likelion.server.domain.group.service;
 
 import com.likelion.server.domain.group.web.dto.CreateGroupRequest;
 import com.likelion.server.domain.group.web.dto.CreateGroupResponse;
+import com.likelion.server.domain.group.web.dto.GroupJoinResponse;
 
 public interface GroupService {
     CreateGroupResponse create(Long userId, CreateGroupRequest req);
+    GroupJoinResponse joinByCode(Long userId, String groupCode);
 }

--- a/src/main/java/com/likelion/server/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/com/likelion/server/domain/group/service/GroupServiceImpl.java
@@ -3,10 +3,14 @@ package com.likelion.server.domain.group.service;
 import com.likelion.server.domain.group.entity.Group;
 import com.likelion.server.domain.group.entity.Member;
 import com.likelion.server.domain.group.entity.enums.Role;
+import com.likelion.server.domain.group.exception.AlreadyGroupMemberException;
+import com.likelion.server.domain.group.exception.GroupErrorCode;
+import com.likelion.server.domain.group.exception.GroupNotFoundException;
 import com.likelion.server.domain.group.repository.GroupMemberRepository;
 import com.likelion.server.domain.group.repository.StudyGroupRepository;
 import com.likelion.server.domain.group.web.dto.CreateGroupRequest;
 import com.likelion.server.domain.group.web.dto.CreateGroupResponse;
+import com.likelion.server.domain.group.web.dto.GroupJoinResponse;
 import com.likelion.server.domain.user.entity.User;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
@@ -65,6 +69,30 @@ public class GroupServiceImpl implements GroupService {
                 saveGroup.getGroupCode(),
                 saveGroup.getImageNum()
         );
+    }
+
+    @Override
+    public GroupJoinResponse joinByCode(Long userId, String groupCode) {
+
+        Group group = studyGroupRepository.findByGroupCode(groupCode);
+        if (group == null) {
+            throw new GroupNotFoundException();
+        }
+
+        // 중복 가입 방지
+        if (groupMemberRepository.existsByGroupIdAndUserId(group.getId(), userId)) {
+            throw new AlreadyGroupMemberException();
+        }
+
+        // Member 엔티티 생성/저장
+        Member member = new Member(
+                group,
+                em.getReference(User.class, userId),
+                Role.MEMBER
+        );
+        groupMemberRepository.save(member);
+
+        return new GroupJoinResponse(group.getId());
     }
 
     private String generateUniqueCode(int length) {

--- a/src/main/java/com/likelion/server/domain/group/web/controller/GroupController.java
+++ b/src/main/java/com/likelion/server/domain/group/web/controller/GroupController.java
@@ -3,6 +3,8 @@ package com.likelion.server.domain.group.web.controller;
 import com.likelion.server.domain.group.service.GroupService;
 import com.likelion.server.domain.group.web.dto.CreateGroupRequest;
 import com.likelion.server.domain.group.web.dto.CreateGroupResponse;
+import com.likelion.server.domain.group.web.dto.GroupJoinRequest;
+import com.likelion.server.domain.group.web.dto.GroupJoinResponse;
 import com.likelion.server.global.response.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
@@ -28,5 +30,15 @@ public class GroupController {
     ) {
         CreateGroupResponse data = groupService.create(userId, createGroupRequest);
         return SuccessResponse.created(data);
+    }
+
+    // 그룹 입장
+    @PostMapping("/group/join")
+    public SuccessResponse<GroupJoinResponse> joinGroup(
+            @AuthenticationPrincipal(expression = "id") Long userId,
+            @Valid @RequestBody GroupJoinRequest groupJoinRequest
+    ) {
+        GroupJoinResponse data = groupService.joinByCode(userId, groupJoinRequest.groupCode());
+        return SuccessResponse.ok(data);
     }
 }

--- a/src/main/java/com/likelion/server/domain/group/web/controller/GroupController.java
+++ b/src/main/java/com/likelion/server/domain/group/web/controller/GroupController.java
@@ -1,4 +1,4 @@
-package com.likelion.server.domain.group.controller;
+package com.likelion.server.domain.group.web.controller;
 
 import com.likelion.server.domain.group.service.GroupService;
 import com.likelion.server.domain.group.web.dto.CreateGroupRequest;

--- a/src/main/java/com/likelion/server/domain/group/web/dto/GroupJoinRequest.java
+++ b/src/main/java/com/likelion/server/domain/group/web/dto/GroupJoinRequest.java
@@ -1,0 +1,8 @@
+package com.likelion.server.domain.group.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record GroupJoinRequest(
+        @NotBlank(message = "그룹코드는 필수입니다.")
+        String groupCode
+) {}

--- a/src/main/java/com/likelion/server/domain/group/web/dto/GroupJoinResponse.java
+++ b/src/main/java/com/likelion/server/domain/group/web/dto/GroupJoinResponse.java
@@ -1,0 +1,3 @@
+package com.likelion.server.domain.group.web.dto;
+
+public record GroupJoinResponse( Long groupId) {}


### PR DESCRIPTION
## 🔍 관련 이슈
<!--
- close #123
-->
- close #15 

<br>

## ✅ 작업 분류
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
1. POST /group/join 엔드포인트를 추가하여 모달에서 입력한 입장코드로 그룹 가입 기능을 구현했습니다.
2. GroupJoinRequest/Response DTO를 추가하고, 멤버 저장 로직을 구현했습니다.
3. 에러코드를 추가해 상황에 맞는 예외 처리를 구현했습니다.
4. StudyGroupRepository와 GroupMemberRepository에 쿼리 메서드를 추가했습니다.

<br>

## 👥 전달사항
<!--
1. User 도메인 구조를 변경하였습니다.
2. User 도메인 사용자 닉네임 필드를 username -> nickname으로 변경하였습니다.
-->

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
### 그룹 입장 성공
<img width="758" height="644" alt="image" src="https://github.com/user-attachments/assets/6ae7a90b-b06b-4fc4-8711-9a2c08bcef38" />

### 이미 입장한 그룹 코드 입력
<img width="761" height="589" alt="image" src="https://github.com/user-attachments/assets/08ba6de8-f694-40fa-a239-f56c93be42f0" />

### 존재하지 않는 그룹 코드 입력
<img width="765" height="588" alt="image" src="https://github.com/user-attachments/assets/bee1774d-99e8-4b28-8d25-4025ea023f90" />
