### PR TITLE
✨ Feat: Pdf 업로드 / 삭제 API 구현

### DIFF
--- a/src/main/java/com/likelion/server/domain/pdf/entity/Pdf.java
+++ b/src/main/java/com/likelion/server/domain/pdf/entity/Pdf.java
@@ -18,11 +18,11 @@ public class Pdf extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "group_id")
+    @JoinColumn(name = "group_id", nullable = false)
     private Group group;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "uploader_id")
+    @JoinColumn(name = "uploader_id", nullable = false)
     private User uploader;
 
     @Column(nullable = false)

--- a/src/main/java/com/likelion/server/domain/pdf/repository/PdfRepository.java
+++ b/src/main/java/com/likelion/server/domain/pdf/repository/PdfRepository.java
@@ -1,0 +1,6 @@
+package com.likelion.server.domain.pdf.repository;
+
+import com.likelion.server.domain.pdf.entity.Pdf;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PdfRepository extends JpaRepository<Pdf, Long> {}

--- a/src/main/java/com/likelion/server/domain/pdf/service/PdfService.java
+++ b/src/main/java/com/likelion/server/domain/pdf/service/PdfService.java
@@ -1,0 +1,121 @@
+package com.likelion.server.domain.pdf.service;
+
+import com.likelion.server.domain.group.entity.Group;
+import com.likelion.server.domain.pdf.entity.Pdf;
+import com.likelion.server.domain.pdf.repository.PdfRepository;
+import com.likelion.server.domain.pdf.web.dto.PdfDeleteResponse;
+import com.likelion.server.domain.pdf.web.dto.PdfUploadResponse;
+import com.likelion.server.domain.user.entity.User;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.ObjectCannedACL;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PdfService {
+
+    private final PdfRepository pdfRepository;
+    private final S3Client s3Client;
+    private final EntityManager em;
+
+    @Value("${bucket-name}")
+    private String bucket;
+
+    // PDF 업로드
+    public PdfUploadResponse upload(Long userId, Long groupId, MultipartFile file) {
+        String originalName = file.getOriginalFilename();
+        String fileKey = String.format("%d/%s", groupId, originalName);
+
+        try {
+            // S3 업로드 요청 생성
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(fileKey)
+                    .contentType(file.getContentType())
+                    .build();
+
+            // 실제 업로드 수행
+            s3Client.putObject(putObjectRequest, RequestBody.fromInputStream(file.getInputStream(), file.getSize()));
+
+        } catch (IOException e) {
+            throw new RuntimeException("S3 업로드 실패", e);
+        }
+
+        // S3 퍼블릭 URL 생성
+        String fileUrl = String.format("https://%s.s3.amazonaws.com/%s", bucket, fileKey);
+
+        // DB에 PDF 정보 저장
+        Pdf pdf = Pdf.builder()
+                .group(em.getReference(Group.class, groupId))
+                .uploader(em.getReference(User.class, userId))
+                .fileName(originalName)
+                .s3Url(fileUrl)
+                .build();
+
+        Pdf saved = pdfRepository.save(pdf);
+        User uploader = em.find(User.class, userId);
+
+        return PdfUploadResponse.builder()
+                .id(saved.getId())
+                .groupId(groupId)
+                .fileName(saved.getFileName())
+                .s3Url(saved.getS3Url())
+                .uploader(new PdfUploadResponse.Uploader(uploader.getId(), uploader.getNickname()))
+                .createdAt(saved.getCreatedAt())
+                .build();
+    }
+
+    // PDF 삭제
+    public PdfDeleteResponse delete(Long pdfId, Long userId) {
+        Pdf pdf = pdfRepository.findById(pdfId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 PDF를 찾을 수 없습니다."));
+
+        // 업로더 본인 확인
+        if (!pdf.getUploader().getId().equals(userId)) {
+            throw new SecurityException("본인이 업로드한 파일만 삭제할 수 있습니다.");
+        }
+
+        // S3 키 추출 (버킷 내 경로)
+        String key = extractS3Key(pdf.getS3Url());
+
+        // S3에서 삭제
+        DeleteObjectRequest deleteRequest = DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+
+        s3Client.deleteObject(deleteRequest);
+
+        // DB에서 삭제
+        pdfRepository.delete(pdf);
+
+
+        User uploader = em.find(User.class, userId);
+
+        return PdfDeleteResponse.builder()
+                .id(pdf.getId())
+                .fileName(pdf.getFileName())
+                .s3Url(pdf.getS3Url())
+                .uploader(new PdfDeleteResponse.Uploader(uploader.getId(), uploader.getNickname()))
+                .deletedAt(LocalDateTime.now())
+                .build();
+    }
+
+    // URL에서 S3 key 부분 추출
+    private String extractS3Key(String s3Url) {
+        int idx = s3Url.indexOf(bucket) + bucket.length() + 1;
+        return s3Url.substring(idx);
+    }
+}

--- a/src/main/java/com/likelion/server/domain/pdf/web/controller/PdfController.java
+++ b/src/main/java/com/likelion/server/domain/pdf/web/controller/PdfController.java
@@ -1,0 +1,40 @@
+package com.likelion.server.domain.pdf.web.controller;
+
+import com.likelion.server.domain.pdf.service.PdfService;
+import com.likelion.server.domain.pdf.web.dto.PdfDeleteResponse;
+import com.likelion.server.domain.pdf.web.dto.PdfUploadResponse;
+import com.likelion.server.global.response.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/pdf")
+public class PdfController {
+
+    private final PdfService pdfService;
+
+    // PDF 업로드
+    @PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public SuccessResponse<PdfUploadResponse> uploadPdf(
+            @AuthenticationPrincipal(expression = "id") Long userId,
+            @RequestParam("group_id") Long groupId,
+            @RequestPart("file") MultipartFile file
+    ) {
+        PdfUploadResponse data = pdfService.upload(userId, groupId, file);
+        return SuccessResponse.created(data);
+    }
+
+    // PDF 삭제
+    @DeleteMapping("/{pdf_id}")
+    public SuccessResponse<PdfDeleteResponse> deletePdf(
+            @AuthenticationPrincipal(expression = "id") Long userId,
+            @PathVariable("pdf_id") Long pdfId
+    ) {
+        PdfDeleteResponse data = pdfService.delete(pdfId, userId);
+        return SuccessResponse.ok(data);
+    }
+}

--- a/src/main/java/com/likelion/server/domain/pdf/web/dto/PdfDeleteResponse.java
+++ b/src/main/java/com/likelion/server/domain/pdf/web/dto/PdfDeleteResponse.java
@@ -1,0 +1,18 @@
+package com.likelion.server.domain.pdf.web.dto;
+
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+
+@Builder
+public record PdfDeleteResponse(
+        Long id,
+        String fileName,
+        String s3Url,
+        Uploader uploader,
+        LocalDateTime deletedAt
+) {
+    @Builder
+    public record Uploader(Long id, String name) {}
+
+}

--- a/src/main/java/com/likelion/server/domain/pdf/web/dto/PdfUploadResponse.java
+++ b/src/main/java/com/likelion/server/domain/pdf/web/dto/PdfUploadResponse.java
@@ -1,0 +1,18 @@
+package com.likelion.server.domain.pdf.web.dto;
+
+import lombok.Builder;
+import java.time.LocalDateTime;
+
+@Builder
+public record PdfUploadResponse(
+        Long id,
+        Long groupId,
+        String fileName,
+        String s3Url,
+        Uploader uploader,
+        LocalDateTime createdAt
+) {
+    @Builder
+    public record Uploader(Long id, String name) {}
+
+}


### PR DESCRIPTION
## 🔍 관련 이슈
- close #18 

<br>

## ✅ 작업 분류
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
  ex) 
  1. pdf 업로드 API 구현
  2. pdf 삭제 API 구현

<br>

## 👥 전달사항
1. S3 자동 업로드 되도록 설정 및 테스트 완료했습니다.

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
1. POST pdf
<img width="847" height="756" alt="image" src="https://github.com/user-attachments/assets/198d5f7a-5b62-44fb-846d-ab1a798ebc1f" />

2. DELETE pdf/{id}
<img width="865" height="847" alt="image" src="https://github.com/user-attachments/assets/32d6c31f-9381-49e1-861f-6442d79252bd" />
