### PR TITLE
✨Feat: QA 게시글 등록 API 구현

### DIFF
--- a/src/main/java/com/likelion/server/domain/group/web/controller/GroupController.java
+++ b/src/main/java/com/likelion/server/domain/group/web/controller/GroupController.java
@@ -8,7 +8,6 @@ import com.likelion.server.domain.group.web.dto.GroupJoinResponse;
 import com.likelion.server.global.response.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;

--- a/src/main/java/com/likelion/server/domain/group/web/dto/GroupJoinResponse.java
+++ b/src/main/java/com/likelion/server/domain/group/web/dto/GroupJoinResponse.java
@@ -1,3 +1,3 @@
 package com.likelion.server.domain.group.web.dto;
 
-public record GroupJoinResponse( Long groupId) {}
+public record GroupJoinResponse(Long groupId) {}

--- a/src/main/java/com/likelion/server/domain/qa/exception/QaErrorCode.java
+++ b/src/main/java/com/likelion/server/domain/qa/exception/QaErrorCode.java
@@ -1,0 +1,18 @@
+package com.likelion.server.domain.qa.exception;
+
+import com.likelion.server.global.response.code.BaseResponseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import static com.likelion.server.global.constant.StaticValue.NOT_FOUND;
+
+@Getter
+@AllArgsConstructor
+public enum QaErrorCode implements BaseResponseCode {
+    QA_404_NOT_FOUND_BY_CODE("QA_404_NOT_FOUND_BY_CODE", NOT_FOUND, "해당 ID의 게시판을 찾을 수 없습니다.");
+
+    private final String code;
+    private final int httpStatus;
+    private final String message;
+}
+

--- a/src/main/java/com/likelion/server/domain/qa/exception/QaNotFoundException.java
+++ b/src/main/java/com/likelion/server/domain/qa/exception/QaNotFoundException.java
@@ -1,0 +1,8 @@
+package com.likelion.server.domain.qa.exception;
+
+
+import com.likelion.server.global.exception.BaseException;
+
+public class QaNotFoundException extends BaseException {
+    public QaNotFoundException() { super(QaErrorCode.QA_404_NOT_FOUND_BY_CODE); }
+}

--- a/src/main/java/com/likelion/server/domain/qa/repository/QaBoardRepository.java
+++ b/src/main/java/com/likelion/server/domain/qa/repository/QaBoardRepository.java
@@ -1,0 +1,6 @@
+package com.likelion.server.domain.qa.repository;
+
+import com.likelion.server.domain.qa.entity.QaBoard;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QaBoardRepository extends JpaRepository<QaBoard, Long> {}

--- a/src/main/java/com/likelion/server/domain/qa/repository/QaPostRepository.java
+++ b/src/main/java/com/likelion/server/domain/qa/repository/QaPostRepository.java
@@ -1,0 +1,6 @@
+package com.likelion.server.domain.qa.repository;
+
+import com.likelion.server.domain.qa.entity.QaPost;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QaPostRepository extends JpaRepository<QaPost, Long> {}

--- a/src/main/java/com/likelion/server/domain/qa/service/QaService.java
+++ b/src/main/java/com/likelion/server/domain/qa/service/QaService.java
@@ -1,0 +1,9 @@
+package com.likelion.server.domain.qa.service;
+
+import com.likelion.server.domain.qa.web.dto.QaPostRequest;
+import com.likelion.server.domain.qa.web.dto.QaPostResponse;
+import com.likelion.server.domain.user.entity.User;
+
+public interface QaService {
+    QaPostResponse createPost(QaPostRequest request, Long currentUserId);
+}

--- a/src/main/java/com/likelion/server/domain/qa/service/QaServiceImpl.java
+++ b/src/main/java/com/likelion/server/domain/qa/service/QaServiceImpl.java
@@ -1,0 +1,52 @@
+package com.likelion.server.domain.qa.service;
+
+import com.likelion.server.domain.qa.entity.QaBoard;
+import com.likelion.server.domain.qa.entity.QaPost;
+import com.likelion.server.domain.qa.exception.QaNotFoundException;
+import com.likelion.server.domain.qa.repository.QaBoardRepository;
+import com.likelion.server.domain.qa.repository.QaPostRepository;
+import com.likelion.server.domain.qa.web.dto.QaPostRequest;
+import com.likelion.server.domain.qa.web.dto.QaPostResponse;
+import com.likelion.server.domain.user.entity.User;
+import com.likelion.server.domain.user.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class QaServiceImpl implements QaService {
+
+    private final QaPostRepository qaPostRepository;
+    private final QaBoardRepository qaBoardRepository;
+    private final UserRepository userRepository;
+
+    @Override
+    @Transactional
+    public QaPostResponse createPost(QaPostRequest request, Long currentUserId) {
+
+        // User 조회
+        User currentUser = userRepository.findById(currentUserId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 ID의 사용자를 찾을 수 없습니다: " + currentUserId));
+
+        // QaBoard 조회
+        QaBoard board = qaBoardRepository.findById(request.getBoardId())
+                .orElseThrow(QaNotFoundException::new);
+
+        // QaPost 엔티티 생성
+        QaPost newPost = QaPost.builder()
+                .board(board)
+                .writer(currentUser)
+                .title(request.getTitle())
+                .content(request.getContent())
+                .build();
+
+        // 엔티티 저장
+        QaPost savedPost = qaPostRepository.save(newPost);
+
+        // return
+        return new QaPostResponse(savedPost);
+    }
+}

--- a/src/main/java/com/likelion/server/domain/qa/web/controller/QaController.java
+++ b/src/main/java/com/likelion/server/domain/qa/web/controller/QaController.java
@@ -1,0 +1,32 @@
+package com.likelion.server.domain.qa.web.controller;
+
+import com.likelion.server.domain.qa.service.QaService;
+import com.likelion.server.domain.qa.web.dto.QaPostRequest;
+import com.likelion.server.domain.qa.web.dto.QaPostResponse;
+import com.likelion.server.domain.user.entity.User;
+import com.likelion.server.global.response.SuccessResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/qa")
+public class QaController {
+
+    private final QaService qaService;
+
+    // QA 게시글 등록
+    @PostMapping("/post")
+    public SuccessResponse<QaPostResponse> createPost(
+            @Valid @RequestBody QaPostRequest request,
+            @AuthenticationPrincipal(expression = "id") Long userId
+    ) {
+        QaPostResponse data = qaService.createPost(request, userId);
+        return SuccessResponse.created(data);
+    }
+}

--- a/src/main/java/com/likelion/server/domain/qa/web/dto/QaPostRequest.java
+++ b/src/main/java/com/likelion/server/domain/qa/web/dto/QaPostRequest.java
@@ -1,0 +1,20 @@
+package com.likelion.server.domain.qa.web.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class QaPostRequest {
+
+    @NotNull(message = "게시판 ID는 필수입니다.")
+    private Long boardId;
+
+    @NotBlank(message = "제목은 필수입니다.")
+    private String title;
+
+    @NotBlank(message = "내용은 필수입니다.")
+    private String content;
+}

--- a/src/main/java/com/likelion/server/domain/qa/web/dto/QaPostResponse.java
+++ b/src/main/java/com/likelion/server/domain/qa/web/dto/QaPostResponse.java
@@ -1,0 +1,36 @@
+package com.likelion.server.domain.qa.web.dto;
+
+import com.likelion.server.domain.qa.entity.QaPost;
+import com.likelion.server.domain.user.entity.User;
+
+import java.time.format.DateTimeFormatter;
+
+public record QaPostResponse(
+        Long id,
+        Long boardId,
+        UserDto user,
+        String title,
+        String content,
+        String createdAt
+) {
+
+    public record UserDto(
+            Long id,
+            String nickname
+    ) {
+        public UserDto(User user) {
+            this(user.getId(), user.getNickname());
+        }
+    }
+
+    public QaPostResponse(QaPost qaPost) {
+        this(
+                qaPost.getId(),
+                qaPost.getBoard().getId(),
+                new UserDto(qaPost.getWriter()),
+                qaPost.getTitle(),
+                qaPost.getContent(),
+                qaPost.getCreatedAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME) // "created_at" 형식
+        );
+    }
+}


### PR DESCRIPTION
## 🔍 관련 이슈
<!--
- close #123
-->
- close #23 

<br>

## ✅ 작업 분류
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
1. Question 엔터티와 QuestionRepository를 추가하여 문항별 생성된 질문 답변 저장 기능을 구현했습니다.
2. QaResponse DTO와 QaService 인터페이스를 정의했습니다.
3. QaServiceImpl에서 GPT 호출, JSON 파싱, DB 저장 로직을 구현했습니다.

<br>

## 👥 전달사항
<!--
1. User 도메인 구조를 변경하였습니다.
2. User 도메인 사용자 닉네임 필드를 username -> nickname으로 변경하였습니다.
-->

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
<img width="753" height="715" alt="image" src="https://github.com/user-attachments/assets/d20fd95c-71ea-4a5e-89d0-9186a5c3473a" />
<img width="755" height="605" alt="image" src="https://github.com/user-attachments/assets/63ea61e7-51f0-464e-a728-115c60d23a3b" />
