### PR TITLE
 Feat: Quiz 생성 및 조회 (객관식 문제 적용 오류 수정 필요)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -39,6 +39,9 @@ dependencies {
 	// gpt
 	implementation 'com.theokanning.openai-gpt3-java:client:0.12.0'
 
+	// PDFBox
+	implementation 'org.apache.pdfbox:pdfbox:2.0.30'
+
 	// test
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/likelion/server/domain/qa/entity/QaBoard.java
+++ b/src/main/java/com/likelion/server/domain/qa/entity/QaBoard.java
@@ -1,5 +1,7 @@
 package com.likelion.server.domain.qa.entity;
 
+import com.likelion.server.domain.group.entity.Group;
+import com.likelion.server.domain.quiz.entity.Quiz;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -9,10 +11,29 @@ import lombok.*;
 @AllArgsConstructor
 @Builder
 public class QaBoard {
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "group_id", nullable = false)
+    private Group group;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "quiz_id")
+    private Quiz quiz;
+
     @Column(nullable = false)
     private String boardName;
+
+
+    // === Setter ===
+    public void setQuiz(Quiz quiz) {
+        this.quiz = quiz;
+    }
+
+    public void setGroup(Group group) {
+        this.group = group;
+    }
 }

--- a/src/main/java/com/likelion/server/domain/qa/repository/QaBoardRepository.java
+++ b/src/main/java/com/likelion/server/domain/qa/repository/QaBoardRepository.java
@@ -1,0 +1,14 @@
+package com.likelion.server.domain.qa.repository;
+
+import com.likelion.server.domain.qa.entity.QaBoard;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface QaBoardRepository extends JpaRepository<QaBoard, Long> {
+
+    // 특정 퀴즈에 연결된 QA 게시판 조회
+    Optional<QaBoard> findByQuizId(Long quizId);
+}

--- a/src/main/java/com/likelion/server/domain/quiz/entity/Quiz.java
+++ b/src/main/java/com/likelion/server/domain/quiz/entity/Quiz.java
@@ -33,5 +33,9 @@ public class Quiz extends BaseEntity {
     private Integer totalQuestions;
 
     @Enumerated(EnumType.STRING)
+    @Column(length = 10)
     private Difficulty difficulty;
+
+    @Column(length = 100)
+    private String questionTypes;
 }

--- a/src/main/java/com/likelion/server/domain/quiz/entity/enums/Difficulty.java
+++ b/src/main/java/com/likelion/server/domain/quiz/entity/enums/Difficulty.java
@@ -1,5 +1,5 @@
 package com.likelion.server.domain.quiz.entity.enums;
 
 public enum Difficulty {
-    EASY, NORMAL, HARD
+    상, 중, 하
 }

--- a/src/main/java/com/likelion/server/domain/quiz/entity/enums/Type.java
+++ b/src/main/java/com/likelion/server/domain/quiz/entity/enums/Type.java
@@ -1,5 +1,5 @@
 package com.likelion.server.domain.quiz.entity.enums;
 
 public enum Type {
-    OX, MULTIPLE, SHORT
+    OX, MULTIPLE_CHOICE, SHORT_ANSWER
 }

--- a/src/main/java/com/likelion/server/domain/quiz/repository/QuizQuestionRepository.java
+++ b/src/main/java/com/likelion/server/domain/quiz/repository/QuizQuestionRepository.java
@@ -1,0 +1,13 @@
+package com.likelion.server.domain.quiz.repository;
+
+import com.likelion.server.domain.quiz.entity.QuizQuestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+import java.util.List;
+
+@Repository
+public interface QuizQuestionRepository extends JpaRepository<QuizQuestion, Long> {
+
+    // ✅ 퀴즈 ID 기준으로 문제 조회
+    List<QuizQuestion> findAllByQuizId(Long quizId);
+}

--- a/src/main/java/com/likelion/server/domain/quiz/repository/QuizRepository.java
+++ b/src/main/java/com/likelion/server/domain/quiz/repository/QuizRepository.java
@@ -1,0 +1,8 @@
+package com.likelion.server.domain.quiz.repository;
+
+import com.likelion.server.domain.quiz.entity.Quiz;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QuizRepository extends JpaRepository<Quiz, Long> {
+    int countByPdfId(Long pdfId);
+}

--- a/src/main/java/com/likelion/server/domain/quiz/service/AiQuizGenerator.java
+++ b/src/main/java/com/likelion/server/domain/quiz/service/AiQuizGenerator.java
@@ -1,0 +1,87 @@
+package com.likelion.server.domain.quiz.service;
+
+import com.likelion.server.domain.pdf.entity.Pdf;
+import com.likelion.server.domain.quiz.entity.Quiz;
+import com.likelion.server.domain.quiz.entity.QuizQuestion;
+import com.likelion.server.domain.quiz.web.dto.CreateQuizRequest;
+import com.theokanning.openai.OpenAiService;
+import com.theokanning.openai.completion.chat.ChatCompletionRequest;
+import com.theokanning.openai.completion.chat.ChatMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.List;
+
+/**
+ * ✅ PDF 내용을 기반으로 GPT를 호출해 퀴즈(정답 + 해설)를 생성하는 orchestrator 클래스
+ */
+@Component
+@RequiredArgsConstructor
+public class AiQuizGenerator {
+
+    private final PdfTextExtractor pdfTextExtractor;   // PDF → 텍스트 변환 담당
+    private final QuizPromptBuilder quizPromptBuilder; // GPT 프롬프트 생성 담당
+    private final QuizResponseParser quizResponseParser; // GPT 응답 파싱 담당
+
+    @Value("${openai.key}")
+    private String openAiKey;
+
+    @Value("${openai.timeout}")
+    private Long timeout;
+
+    /**
+     * ✅ 전체 퀴즈 생성 절차
+     * 1. S3에서 PDF 텍스트 추출
+     * 2. GPT 프롬프트 구성
+     * 3. GPT 호출
+     * 4. 응답 파싱 → QuizQuestion 리스트 반환
+     */
+    public List<QuizQuestion> generateQuestions(Pdf pdf, Quiz quiz, CreateQuizRequest req) {
+        try {
+            // PDF 텍스트 추출
+            String pdfText = pdfTextExtractor.extract(pdf);
+
+            // PDF 내용 길이 제한 (8,000자 초과 시 잘라내기)
+            if (pdfText.length() > 6500) {
+                System.out.println("[DEBUG] ✂️ PDF 내용이 너무 깁니다. 6500자로 잘라냅니다.");
+                pdfText = pdfText.substring(0, 6500);
+            }
+
+            // 프롬프트 구성
+            String prompt = quizPromptBuilder.build(pdfText, req, pdf.getFileName());
+
+            System.out.println("[DEBUG] 🧠 프롬프트 길이: " + prompt.length());
+            System.out.println("[DEBUG] 🧠 요청 난이도: " + req.difficulty());
+            System.out.println("[DEBUG] 🧠 문제 수: " + req.total_questions());
+            System.out.println("[DEBUG] 🧠 Key 존재 여부: " + (openAiKey != null));
+
+
+            //⃣ GPT API 호출
+            OpenAiService service = new OpenAiService(openAiKey, Duration.ofSeconds(180));
+            ChatCompletionRequest chatRequest = ChatCompletionRequest.builder()
+                    .model("gpt-4o")
+                    .messages(List.of(
+                            new ChatMessage("system", "너는 대학생을 위한 학습용 퀴즈를 생성하는 AI 교사야."),
+                            new ChatMessage("user", prompt)
+                    ))
+                    .temperature(0.7)
+                    .maxTokens(800)
+                    .build();
+
+            String aiResponse = service.createChatCompletion(chatRequest)
+                    .getChoices()
+                    .get(0)
+                    .getMessage()
+                    .getContent();
+
+            // 4️⃣ GPT 응답 파싱 → QuizQuestion 엔티티 리스트 변환
+            return quizResponseParser.parse(aiResponse, quiz);
+
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new RuntimeException("AI 퀴즈 생성 중 오류 발생: " + e.getMessage(), e);
+        }
+    }
+}

--- a/src/main/java/com/likelion/server/domain/quiz/service/PdfTextExtractor.java
+++ b/src/main/java/com/likelion/server/domain/quiz/service/PdfTextExtractor.java
@@ -1,0 +1,71 @@
+package com.likelion.server.domain.quiz.service;
+import com.likelion.server.domain.pdf.entity.Pdf;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.core.ResponseInputStream;
+import software.amazon.awssdk.services.s3.model.GetObjectRequest;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
+
+import java.io.File;
+import java.io.FileOutputStream;
+
+@Component
+@RequiredArgsConstructor
+public class PdfTextExtractor {
+
+    private final S3Client s3Client;
+    @Value("${bucket-name}")
+    private String bucket;
+
+    public String extract(Pdf pdf) {
+
+        try {
+            String key = extractS3Key(pdf.getS3Url());
+            // [1] S3 다운로드 정보 출력
+            System.out.println("[DEBUG] 📄 PDF S3 URL: " + pdf.getS3Url());
+            System.out.println("[DEBUG] 📦 Extracted Key: " + key);
+
+
+            ResponseInputStream<?> stream = s3Client.getObject(GetObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(key)
+                    .build());
+
+            File tempFile = File.createTempFile("quiz_", ".pdf");
+            try (FileOutputStream fos = new FileOutputStream(tempFile)) {
+                stream.transferTo(fos);
+            }
+            // [2] 파일 다운로드 완료 후 파일 크기 확인
+            System.out.println("[DEBUG] 📁 Downloaded temp file: " + tempFile.getAbsolutePath());
+            System.out.println("[DEBUG] 📏 File size: " + tempFile.length() + " bytes");
+
+            // [3] 빈 파일이면 바로 예외 발생시키기
+            if (tempFile.length() == 0) {
+                throw new RuntimeException("S3에서 받은 PDF 파일이 비어 있습니다. 업로드 또는 Key를 확인하세요.");
+            }
+
+            // [4] PDF 텍스트 추출
+            try (PDDocument doc = PDDocument.load(tempFile)) {
+                PDFTextStripper stripper = new PDFTextStripper();
+                String text = stripper.getText(doc);
+
+                System.out.println("[DEBUG] ✅ PDF 텍스트 추출 완료, 길이: " + text.length());
+
+                return text.length() > 8000 ? text.substring(0, 8000) : text;
+            } finally {
+                tempFile.delete();
+            }
+
+        } catch (Exception e) { // 콘솔에 자세한 원인 출력
+            throw new RuntimeException("PDF 텍스트 추출 실패", e);
+        }
+    }
+
+    private String extractS3Key(String s3Url) {
+        int idx = s3Url.indexOf(".amazonaws.com/") + ".amazonaws.com/".length();
+        return s3Url.substring(idx);
+    }
+}

--- a/src/main/java/com/likelion/server/domain/quiz/service/QuizPromptBuilder.java
+++ b/src/main/java/com/likelion/server/domain/quiz/service/QuizPromptBuilder.java
@@ -1,0 +1,64 @@
+package com.likelion.server.domain.quiz.service;
+
+import com.likelion.server.domain.quiz.web.dto.CreateQuizRequest;
+import org.springframework.stereotype.Component;
+
+/**
+ * GPT 퀴즈 생성용 프롬프트를 구성하는 클래스
+ * - PDF 내용 기반 문제 생성
+ * - 난이도(상/중/하) 기준 포함
+ * - 정답(answer) + 해설(explanation) 필드 포함
+ */
+
+@Component
+public class QuizPromptBuilder {
+
+    public String build(String pdfContent, CreateQuizRequest req, String pdfTitle) {
+        return String.format("""
+        당신은 대학생을 위한 학습용 퀴즈를 만들어주는 AI 교사입니다.
+        오직 아래의 PDF 내용 안에서만 문제를 출제해야 합니다.
+        외부 지식은 절대 사용하지 마세요.
+
+        🎯 목표:
+        PDF 내용을 기반으로 %d개의 퀴즈 문제를 생성하세요.
+
+        🧩 문제 조건:
+        - 난이도는 "%s"입니다.
+        - 문제 유형은 다음 중에서 골라 다양하게 섞어주세요: %s.
+        - 각 문제는 반드시 다음 4개의 속성을 가져야 합니다:
+          • question : 문제 본문 (학생이 답변해야 할 질문)
+          • answer : 정답
+          • type : 문제 유형 (OX / 객관식 / 단답형)
+          • explanation : 간단한 해설 (정답 이유나 추가 설명)
+        - 모든 문제는 아래 JSON 형식으로만 출력하세요.
+        - 설명, 인사말, 추가 텍스트 없이 JSON 배열만 출력해야 합니다.
+
+        📘 출력 예시 (정확히 이 형식으로만 출력하세요):
+        [
+          {
+            "question": "4호선톤 프로젝트의 주요 기술 스택은 무엇인가?",
+            "answer": "Django",
+            "type": "객관식",
+            "explanation": "Django는 Python 기반 백엔드 프레임워크입니다."
+          },
+          {
+            "question": "4호선톤은 협업 중심의 프로젝트이다. (O/X)",
+            "answer": "O",
+            "type": "OX",
+            "explanation": "팀 단위 협업이 핵심인 프로젝트입니다."
+          }
+        ]
+
+        ⚖️ 난이도 기준:
+        - 상: 개념 응용, 문장 해석, 세부적 내용 이해가 필요한 문제
+        - 중: 핵심 개념, 원리, 주요 내용을 직접적으로 묻는 문제
+        - 하: 정의, 용어, 단순 사실을 확인하는 문제
+
+        📄 PDF 제목: %s
+        📑 PDF 내용:
+        %s
+    """, req.total_questions(), req.difficulty(),
+                String.join(", ", req.question_types()), pdfTitle, pdfContent);
+    }
+}
+

--- a/src/main/java/com/likelion/server/domain/quiz/service/QuizResponseParser.java
+++ b/src/main/java/com/likelion/server/domain/quiz/service/QuizResponseParser.java
@@ -1,0 +1,132 @@
+package com.likelion.server.domain.quiz.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.likelion.server.domain.quiz.entity.Quiz;
+import com.likelion.server.domain.quiz.entity.QuizQuestion;
+import com.likelion.server.domain.quiz.entity.enums.Type;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class QuizResponseParser {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public List<QuizQuestion> parse(String aiResponse, Quiz quiz) {
+        List<QuizQuestion> questions = new ArrayList<>();
+        String cleaned = aiResponse; // 바깥에서 선언해서 어디서든 접근 가능
+
+        try {
+            System.out.println("\n==============================");
+            System.out.println("[DEBUG] 🧠 GPT 응답 원문 ↓↓↓");
+            System.out.println(aiResponse);
+            System.out.println("==============================");
+
+            JsonNode root = null;
+            try {
+                // ✅ 백틱(```) 및 제어문자 제거
+                cleaned = aiResponse
+                        .replaceAll("(?s)```json", "")
+                        .replaceAll("(?s)```", "")
+                        .replaceAll("(?s)`", "")
+                        .replaceAll("[\\uFEFF]", "")
+                        .replaceAll("(?s)^\\s+", "")
+                        .replaceAll("(?s)\\s+$", "")
+                        .trim();
+
+                System.out.println("[DEBUG] 🧹 백틱 제거 후 첫 문자: '" +
+                        cleaned.substring(0, Math.min(5, cleaned.length())) + "'");
+
+                root = objectMapper.readTree(cleaned);
+
+            } catch (Exception e1) {
+                System.err.println("⚠️ 1차 파싱 실패 → 재시도 중...");
+                try {
+                    // 혹시 남은 제어문자 제거 후 재시도
+                    String retry = aiResponse.replaceAll("[^\\x20-\\x7E]", "").trim();
+                    root = objectMapper.readTree(retry);
+                } catch (Exception e2) {
+                    System.err.println("❌ JSON 파싱 완전 실패: " + e2.getMessage());
+                    return createFallback(quiz);
+                }
+            }
+
+            System.out.println("[DEBUG] ✂️ 정제된 응답 시작 문자열: " +
+                    cleaned.substring(0, Math.min(100, cleaned.length())));
+
+            if (!root.isArray()) {
+                System.err.println("❌ GPT 응답이 JSON 배열이 아닙니다.");
+                return createFallback(quiz);
+            }
+
+            // ✅ 각 문항 파싱
+            for (JsonNode node : root) {
+                String questionText = node.path("question").asText("");
+                String correctAnswer = node.path("answer").asText("");
+                String typeStr = node.path("type").asText("");
+                String explanation = node.path("explanation").asText("");
+
+                if (questionText.isBlank() || correctAnswer.isBlank()) continue;
+
+                Type type = convertType(typeStr);
+
+                QuizQuestion question = QuizQuestion.builder()
+                        .quiz(quiz)
+                        .type(type)
+                        .questionText(questionText)
+                        .correctAnswer(correctAnswer)
+                        .explanation(explanation)
+                        .build();
+
+                questions.add(question);
+                System.out.println("[DEBUG] ✅ 문제 추가됨 → " + questionText);
+            }
+
+            System.out.println("[DEBUG] 🎯 최종 파싱된 문제 개수: " + questions.size());
+            System.out.println("==============================\n");
+
+            if (questions.isEmpty()) {
+                return createFallback(quiz);
+            }
+
+        } catch (Exception e) {
+            System.err.println("❌ GPT 응답 파싱 중 예외 발생: " + e.getMessage());
+            e.printStackTrace();
+            return createFallback(quiz);
+        }
+
+        return questions;
+    }
+
+    private List<QuizQuestion> createFallback(Quiz quiz) {
+        List<QuizQuestion> fallback = new ArrayList<>();
+        fallback.add(QuizQuestion.builder()
+                .quiz(quiz)
+                .type(Type.OX)
+                .questionText("AI 퀴즈 생성 결과를 파싱하지 못했습니다.")
+                .correctAnswer("N/A")
+                .explanation("GPT 응답 형식을 확인하세요.")
+                .build());
+        return fallback;
+    }
+
+    // ✅ Type 문자열 → Enum 변환
+    private Type convertType(String typeStr) {
+        if (typeStr == null || typeStr.isBlank()) return Type.OX;
+        typeStr = typeStr.trim().toUpperCase();
+
+        if (typeStr.contains("OX")) return Type.OX;
+        if (typeStr.contains("객관")) return Type.MULTIPLE_CHOICE;
+        if (typeStr.contains("단답")) return Type.SHORT_ANSWER;
+
+        try {
+            return Type.valueOf(typeStr);
+        } catch (IllegalArgumentException e) {
+            System.err.println("[WARN] 알 수 없는 Type: " + typeStr + " → 기본값 OX 사용");
+            return Type.OX;
+        }
+    }
+}

--- a/src/main/java/com/likelion/server/domain/quiz/service/QuizService.java
+++ b/src/main/java/com/likelion/server/domain/quiz/service/QuizService.java
@@ -1,0 +1,11 @@
+package com.likelion.server.domain.quiz.service;
+
+import com.likelion.server.domain.quiz.web.dto.CreateQuizRequest;
+import com.likelion.server.domain.quiz.web.dto.CreateQuizResponse;
+import com.likelion.server.domain.quiz.web.dto.QuizDetailResponse;
+
+public interface QuizService {
+    CreateQuizResponse createQuiz(Long userId, CreateQuizRequest request);
+
+    QuizDetailResponse getQuizDetail(Long quizId);
+}

--- a/src/main/java/com/likelion/server/domain/quiz/service/QuizServiceImpl.java
+++ b/src/main/java/com/likelion/server/domain/quiz/service/QuizServiceImpl.java
@@ -1,0 +1,137 @@
+package com.likelion.server.domain.quiz.service;
+
+import com.likelion.server.domain.pdf.entity.Pdf;
+import com.likelion.server.domain.pdf.repository.PdfRepository;
+import com.likelion.server.domain.qa.entity.QaBoard;
+import com.likelion.server.domain.qa.repository.QaBoardRepository;
+import com.likelion.server.domain.quiz.entity.Quiz;
+import com.likelion.server.domain.quiz.entity.QuizQuestion;
+import com.likelion.server.domain.quiz.entity.enums.Difficulty;
+import com.likelion.server.domain.quiz.entity.enums.Type;
+import com.likelion.server.domain.quiz.repository.QuizRepository;
+import com.likelion.server.domain.quiz.repository.QuizQuestionRepository;
+import com.likelion.server.domain.quiz.web.dto.CreateQuizRequest;
+import com.likelion.server.domain.quiz.web.dto.CreateQuizResponse;
+import com.likelion.server.domain.quiz.web.dto.QuizDetailResponse;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+import static com.likelion.server.domain.quiz.entity.enums.Type.*;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class QuizServiceImpl implements QuizService {
+
+    private final QuizRepository quizRepository;
+    private final PdfRepository pdfRepository;
+    private final QuizQuestionRepository quizQuestionRepository;
+    private final QaBoardRepository qaBoardRepository;
+    private final AiQuizGenerator aiQuizGenerator;
+    private final EntityManager em;
+
+    @Override
+    public CreateQuizResponse createQuiz(Long userId, CreateQuizRequest request) {
+
+        // PDF 검증
+        Pdf pdf = pdfRepository.findById(request.pdf_id())
+                .orElseThrow(() -> new IllegalArgumentException("해당 PDF를 찾을 수 없습니다."));
+
+        // 라운드 계산
+        int round = quizRepository.countByPdfId(pdf.getId()) + 1;
+
+        // String → Difficulty enum 변환
+        Difficulty difficulty = switch (request.difficulty()) {
+            case "상" -> Difficulty.상;
+            case "중" -> Difficulty.중;
+            case "하" -> Difficulty.하;
+            default -> throw new IllegalArgumentException("잘못된 난이도 값입니다: " + request.difficulty());
+        };
+
+        // Quiz 생성
+        Quiz quiz = Quiz.builder()
+                .pdf(pdf)
+                .round(round)
+                .difficulty(difficulty)
+                .questionTypes(String.join(",", request.question_types()))
+                .totalQuestions(request.total_questions())
+                .title(pdf.getFileName())
+                .build();
+        Quiz savedQuiz = quizRepository.saveAndFlush(quiz);
+
+        // AI 호출 (동기)
+        List<QuizQuestion> generatedQuestions = aiQuizGenerator.generateQuestions(pdf, quiz, request);
+
+        // 생성된 문제 저장
+        quizQuestionRepository.saveAll(generatedQuestions);
+
+        // QA 게시판 생성
+        QaBoard qaBoard = QaBoard.builder()
+                .quiz(quiz)
+                .boardName(pdf.getFileName())
+                .group(pdf.getGroup())
+                .build();
+        qaBoardRepository.save(qaBoard);
+
+        // 응답 생성
+        return CreateQuizResponse.builder()
+                .id(quiz.getId())
+                .pdf_id(pdf.getId())
+                .round(round)
+                .difficulty(Difficulty.valueOf(quiz.getDifficulty().name()))
+                .question_types(request.question_types())
+                .total_questions(quiz.getTotalQuestions())
+                .qa_board(new CreateQuizResponse.QaBoard(
+                        qaBoard.getId(),
+                        qaBoard.getBoardName()
+                ))
+                .build();
+    }
+
+
+    // 퀴즈 조회
+    @Override
+    public QuizDetailResponse getQuizDetail(Long quizId) {
+        Quiz quiz = quizRepository.findById(quizId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 퀴즈를 찾을 수 없습니다."));
+
+        List<QuizQuestion> questions = quizQuestionRepository.findAllByQuizId(quizId);
+
+        return QuizDetailResponse.builder()
+                .quiz(new QuizDetailResponse.QuizInfo(
+                        quiz.getId(),
+                        quiz.getPdf().getId(),
+                        quiz.getPdf().getFileName(),
+                        quiz.getDifficulty().name(),
+                        quiz.getRound(),
+                        quiz.getTotalQuestions(),
+                        quiz.getCreatedAt()
+                ))
+                .questions(
+                        questions.stream()
+                                .map(q -> new QuizDetailResponse.QuestionInfo(
+                                        q.getId(),
+                                        convertTypeToKorean(q.getType()),
+                                        q.getQuestionText(),
+                                        q.getCorrectAnswer(),
+                                        q.getExplanation()
+                                ))
+                                .toList()
+                )
+                .build();
+    }
+
+    private String convertTypeToKorean(Type type) {
+        return switch (type) {
+            case OX -> "OX";
+            case MULTIPLE_CHOICE -> "객관식";
+            case SHORT_ANSWER -> "단답형";
+        };
+    }
+
+
+}

--- a/src/main/java/com/likelion/server/domain/quiz/web/controller/QuizController.java
+++ b/src/main/java/com/likelion/server/domain/quiz/web/controller/QuizController.java
@@ -1,0 +1,38 @@
+package com.likelion.server.domain.quiz.web.controller;
+
+import com.likelion.server.domain.quiz.service.QuizService;
+import com.likelion.server.domain.quiz.web.dto.CreateQuizRequest;
+import com.likelion.server.domain.quiz.web.dto.CreateQuizResponse;
+import com.likelion.server.domain.quiz.web.dto.QuizDetailResponse;
+import com.likelion.server.global.response.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/quiz")
+public class QuizController {
+
+    private final QuizService quizService;
+
+    @PostMapping("/create")
+    public SuccessResponse<CreateQuizResponse> createQuiz(
+            @AuthenticationPrincipal(expression = "id") Long userId,
+            @RequestBody CreateQuizRequest request
+    ) {
+        CreateQuizResponse data = quizService.createQuiz(userId, request);
+        return SuccessResponse.created(data);
+    }
+
+
+    // 퀴즈 조회
+    @GetMapping("/{quiz_id}")
+    public SuccessResponse<QuizDetailResponse> getQuizDetail(
+            @AuthenticationPrincipal(expression = "id") Long userId,
+            @PathVariable("quiz_id") Long quizId
+    ) {
+        QuizDetailResponse data = quizService.getQuizDetail(quizId);
+        return SuccessResponse.ok(data);
+    }
+}

--- a/src/main/java/com/likelion/server/domain/quiz/web/dto/CreateQuizRequest.java
+++ b/src/main/java/com/likelion/server/domain/quiz/web/dto/CreateQuizRequest.java
@@ -1,0 +1,10 @@
+package com.likelion.server.domain.quiz.web.dto;
+
+import java.util.List;
+
+public record CreateQuizRequest(
+        Long pdf_id,
+        String difficulty,
+        List<String> question_types,
+        Integer total_questions
+) {}

--- a/src/main/java/com/likelion/server/domain/quiz/web/dto/CreateQuizResponse.java
+++ b/src/main/java/com/likelion/server/domain/quiz/web/dto/CreateQuizResponse.java
@@ -1,0 +1,23 @@
+package com.likelion.server.domain.quiz.web.dto;
+
+import com.likelion.server.domain.quiz.entity.enums.Difficulty;
+import lombok.Builder;
+import java.util.List;
+
+@Builder
+public record CreateQuizResponse(
+        Long id,
+        Long pdf_id,
+        Integer round,
+        Difficulty difficulty,
+        List<String> question_types,
+        Integer total_questions,
+        String status,
+        QaBoard qa_board
+) {
+    @Builder
+    public record QaBoard(
+            Long board_id,
+            String title
+    ) {}
+}

--- a/src/main/java/com/likelion/server/domain/quiz/web/dto/QuizDetailResponse.java
+++ b/src/main/java/com/likelion/server/domain/quiz/web/dto/QuizDetailResponse.java
@@ -1,0 +1,42 @@
+package com.likelion.server.domain.quiz.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class QuizDetailResponse {
+
+    private QuizInfo quiz;
+    private List<QuestionInfo> questions;
+
+    @Getter
+    @AllArgsConstructor
+    public static class QuizInfo {
+        private Long id;
+        private Long pdf_id;
+        private String title;
+        private String difficulty;
+        private int round;
+        private int total_questions;
+        private LocalDateTime createdAt;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    public static class QuestionInfo {
+        private Long id;
+        private String type;
+        private String question_text;
+        private String correct_answer;
+        private String explanation;
+    }
+}
+


### PR DESCRIPTION
## 🔍 관련 이슈
- #22 

<br>

## ✅ 작업 분류
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
1. GPT 기반 AI 퀴즈 생성 및 저장
2. 퀴즈 생성 시 자동 QA 게시판 생성
3. 퀴즈 목록 상세 조회 구현

<br>

## 👥 전달사항
1. gpt가 최대 8000자가 최대여서 pdf를 text로 변환 후 8000자가 넘어가는 건 어쩔 수 없이 잘랐습니다.
2. 10문제 이상으로 넘어가면 지연시간이 너무 길어서 현재 동기 방식으로는 최대문제 20개는 불가능해보입니다. 추후 비동기 방식으로 업데이트 시 문제 수를 늘릴 수 있을 것 같습니다.
3. 문제 생성을 pdf 에서 text로 변환시키는 과정이 있어 파일을 pdf로 제한하였습니다.
4. 현재 객관식 문제가 안 만들어지는 오류가 있어 해결 후 PR 예정입니다.

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
1. POST  /quiz/create
<img width="798" height="880" alt="image" src="https://github.com/user-attachments/assets/2245098f-039a-4f35-b8b1-cd5155dac78c" />

2. GET /quiz/{quiz_id}
<img width="883" height="951" alt="image" src="https://github.com/user-attachments/assets/f94252f9-ddef-4af9-8a3f-a92d347e11d0" />

