### PR TITLE
✨Feat: QA 댓글 등록 API 구현

### DIFF
--- a/src/main/java/com/likelion/server/domain/qa/exception/QaErrorCode.java
+++ b/src/main/java/com/likelion/server/domain/qa/exception/QaErrorCode.java
@@ -9,7 +9,8 @@ import static com.likelion.server.global.constant.StaticValue.NOT_FOUND;
 @Getter
 @AllArgsConstructor
 public enum QaErrorCode implements BaseResponseCode {
-    QA_404_NOT_FOUND_BY_CODE("QA_404_NOT_FOUND_BY_CODE", NOT_FOUND, "해당 ID의 게시판을 찾을 수 없습니다.");
+    QA_404_NOT_FOUND_BY_CODE("QA_404_NOT_FOUND_BY_CODE", NOT_FOUND, "해당 ID의 게시판을 찾을 수 없습니다."),
+    QA_POST_NOT_FOUND("QA_POST_404_NOT_FOUND", NOT_FOUND, "해당 ID의 게시글을 찾을 수 없습니다.");
 
     private final String code;
     private final int httpStatus;

--- a/src/main/java/com/likelion/server/domain/qa/exception/QaPostNotFoundException.java
+++ b/src/main/java/com/likelion/server/domain/qa/exception/QaPostNotFoundException.java
@@ -1,0 +1,7 @@
+package com.likelion.server.domain.qa.exception;
+
+import com.likelion.server.global.exception.BaseException;
+
+public class QaPostNotFoundException extends BaseException {
+    public QaPostNotFoundException() { super(QaErrorCode.QA_POST_NOT_FOUND); }
+}

--- a/src/main/java/com/likelion/server/domain/qa/repository/QaCommentRepository.java
+++ b/src/main/java/com/likelion/server/domain/qa/repository/QaCommentRepository.java
@@ -1,0 +1,6 @@
+package com.likelion.server.domain.qa.repository;
+
+import com.likelion.server.domain.qa.entity.QaComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface QaCommentRepository extends JpaRepository<QaComment, Long> {}

--- a/src/main/java/com/likelion/server/domain/qa/service/QaService.java
+++ b/src/main/java/com/likelion/server/domain/qa/service/QaService.java
@@ -1,9 +1,12 @@
 package com.likelion.server.domain.qa.service;
 
+import com.likelion.server.domain.qa.web.dto.QaCommentRequest;
+import com.likelion.server.domain.qa.web.dto.QaCommentResponse;
 import com.likelion.server.domain.qa.web.dto.QaPostRequest;
 import com.likelion.server.domain.qa.web.dto.QaPostResponse;
 import com.likelion.server.domain.user.entity.User;
 
 public interface QaService {
     QaPostResponse createPost(QaPostRequest request, Long currentUserId);
+    QaCommentResponse createComment(QaCommentRequest request, Long currentUserId);
 }

--- a/src/main/java/com/likelion/server/domain/qa/service/QaServiceImpl.java
+++ b/src/main/java/com/likelion/server/domain/qa/service/QaServiceImpl.java
@@ -1,10 +1,15 @@
 package com.likelion.server.domain.qa.service;
 
 import com.likelion.server.domain.qa.entity.QaBoard;
+import com.likelion.server.domain.qa.entity.QaComment;
 import com.likelion.server.domain.qa.entity.QaPost;
 import com.likelion.server.domain.qa.exception.QaNotFoundException;
+import com.likelion.server.domain.qa.exception.QaPostNotFoundException;
 import com.likelion.server.domain.qa.repository.QaBoardRepository;
+import com.likelion.server.domain.qa.repository.QaCommentRepository;
 import com.likelion.server.domain.qa.repository.QaPostRepository;
+import com.likelion.server.domain.qa.web.dto.QaCommentRequest;
+import com.likelion.server.domain.qa.web.dto.QaCommentResponse;
 import com.likelion.server.domain.qa.web.dto.QaPostRequest;
 import com.likelion.server.domain.qa.web.dto.QaPostResponse;
 import com.likelion.server.domain.user.entity.User;
@@ -21,6 +26,7 @@ public class QaServiceImpl implements QaService {
 
     private final QaPostRepository qaPostRepository;
     private final QaBoardRepository qaBoardRepository;
+    private final QaCommentRepository qaCommentRepository;
     private final UserRepository userRepository;
 
     @Override
@@ -32,15 +38,15 @@ public class QaServiceImpl implements QaService {
                 .orElseThrow(() -> new EntityNotFoundException("해당 ID의 사용자를 찾을 수 없습니다: " + currentUserId));
 
         // QaBoard 조회
-        QaBoard board = qaBoardRepository.findById(request.getBoardId())
+        QaBoard board = qaBoardRepository.findById(request.boardId())
                 .orElseThrow(QaNotFoundException::new);
 
         // QaPost 엔티티 생성
         QaPost newPost = QaPost.builder()
                 .board(board)
                 .writer(currentUser)
-                .title(request.getTitle())
-                .content(request.getContent())
+                .title(request.title())
+                .content(request.content())
                 .build();
 
         // 엔티티 저장
@@ -48,5 +54,31 @@ public class QaServiceImpl implements QaService {
 
         // return
         return new QaPostResponse(savedPost);
+    }
+
+    @Override
+    @Transactional
+    public QaCommentResponse createComment(QaCommentRequest request, Long currentUserId) {
+
+        // 사용자 조회
+        User currentUser = userRepository.findById(currentUserId)
+                .orElseThrow(() -> new EntityNotFoundException("해당 ID의 사용자를 찾을 수 없습니다: " + currentUserId));
+
+        // 부모 게시글(QaPost) 조회
+        QaPost parentPost = qaPostRepository.findById(request.postId())
+                .orElseThrow(QaPostNotFoundException::new);
+
+        // 댓글 엔티티 생성
+        QaComment newComment = QaComment.builder()
+                .post(parentPost)
+                .user(currentUser)
+                .content(request.content())
+                .build();
+
+        // 댓글 저장
+        QaComment savedComment = qaCommentRepository.save(newComment);
+
+        // Return
+        return new QaCommentResponse(savedComment);
     }
 }

--- a/src/main/java/com/likelion/server/domain/qa/web/controller/QaController.java
+++ b/src/main/java/com/likelion/server/domain/qa/web/controller/QaController.java
@@ -1,6 +1,8 @@
 package com.likelion.server.domain.qa.web.controller;
 
 import com.likelion.server.domain.qa.service.QaService;
+import com.likelion.server.domain.qa.web.dto.QaCommentRequest;
+import com.likelion.server.domain.qa.web.dto.QaCommentResponse;
 import com.likelion.server.domain.qa.web.dto.QaPostRequest;
 import com.likelion.server.domain.qa.web.dto.QaPostResponse;
 import com.likelion.server.domain.user.entity.User;
@@ -27,6 +29,16 @@ public class QaController {
             @AuthenticationPrincipal(expression = "id") Long userId
     ) {
         QaPostResponse data = qaService.createPost(request, userId);
+        return SuccessResponse.created(data);
+    }
+
+    // QA 게시글 댓글 등록
+    @PostMapping("/comment") //
+    public SuccessResponse<QaCommentResponse> createComment(
+            @Valid @RequestBody QaCommentRequest request,
+            @AuthenticationPrincipal(expression = "id") Long userId
+    ) {
+        QaCommentResponse data = qaService.createComment(request, userId);
         return SuccessResponse.created(data);
     }
 }

--- a/src/main/java/com/likelion/server/domain/qa/web/dto/QaCommentRequest.java
+++ b/src/main/java/com/likelion/server/domain/qa/web/dto/QaCommentRequest.java
@@ -1,0 +1,15 @@
+package com.likelion.server.domain.qa.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+public record QaCommentRequest(
+        @NotNull(message = "게시글 ID는 필수입니다.")
+        @JsonProperty("post_id")
+        Long postId,
+
+        @NotBlank(message = "댓글 내용은 필수입니다.")
+        String content
+) {
+}

--- a/src/main/java/com/likelion/server/domain/qa/web/dto/QaCommentResponse.java
+++ b/src/main/java/com/likelion/server/domain/qa/web/dto/QaCommentResponse.java
@@ -1,0 +1,35 @@
+package com.likelion.server.domain.qa.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.likelion.server.domain.qa.entity.QaComment;
+import com.likelion.server.domain.user.entity.User;
+import java.time.format.DateTimeFormatter;
+
+public record QaCommentResponse(
+        Long id,
+        @JsonProperty("post_id")
+        Long postId,
+        UserDto user,
+        String content,
+        @JsonProperty("created_at")
+        String createdAt
+) {
+    public record UserDto(
+            Long id,
+            String nickname
+    ) {
+        public UserDto(User user) {
+            this(user.getId(), user.getNickname());
+        }
+    }
+
+    public QaCommentResponse(QaComment qaComment) {
+        this(
+                qaComment.getId(),
+                qaComment.getPost().getId(),
+                new UserDto(qaComment.getUser()),
+                qaComment.getContent(),
+                qaComment.getCreatedAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+        );
+    }
+}

--- a/src/main/java/com/likelion/server/domain/qa/web/dto/QaPostRequest.java
+++ b/src/main/java/com/likelion/server/domain/qa/web/dto/QaPostRequest.java
@@ -2,19 +2,14 @@ package com.likelion.server.domain.qa.web.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
-public class QaPostRequest {
+public record QaPostRequest(
+        @NotNull(message = "게시판 ID는 필수입니다.")
+        Long boardId,
 
-    @NotNull(message = "게시판 ID는 필수입니다.")
-    private Long boardId;
+        @NotBlank(message = "제목은 필수입니다.")
+        String title,
 
-    @NotBlank(message = "제목은 필수입니다.")
-    private String title;
-
-    @NotBlank(message = "내용은 필수입니다.")
-    private String content;
-}
+        @NotBlank(message = "내용은 필수입니다.")
+        String content
+) {}

--- a/src/main/java/com/likelion/server/domain/qa/web/dto/QaPostResponse.java
+++ b/src/main/java/com/likelion/server/domain/qa/web/dto/QaPostResponse.java
@@ -30,7 +30,7 @@ public record QaPostResponse(
                 new UserDto(qaPost.getWriter()),
                 qaPost.getTitle(),
                 qaPost.getContent(),
-                qaPost.getCreatedAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME) // "created_at" 형식
+                qaPost.getCreatedAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
         );
     }
 }


### PR DESCRIPTION
## 🔍 관련 이슈
<!--
- close #123
-->
- close #25 

<br>

## ✅ 작업 분류
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
1. QaComment 엔티티 저장을 위한 QaCommentRepository를 추가했습니다.
2. QA 댓글 등록 API (POST /qa/comment)의 Request/Response DTO를 정의했습니다.
3. 댓글 작성 시 부모 게시글(QaPost) ID 조회 실패 시 처리할 QaPostNotFoundException을 추가했습니다.
4. QaService 및 QaServiceImpl에 댓글 등록 비즈니스 로직 (createComment)을 구현했습니다.
5. QaController에 QA 댓글 등록 API 엔드포인트를 추가했습니다.

<br>

## 👥 전달사항
<!--
1. User 도메인 구조를 변경하였습니다.
2. User 도메인 사용자 닉네임 필드를 username -> nickname으로 변경하였습니다.
-->

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
<img width="759" height="700" alt="image" src="https://github.com/user-attachments/assets/d275f0b9-4792-4bf6-bda8-9c6e825c24f1" />
<img width="759" height="700" alt="image" src="https://github.com/user-attachments/assets/c87f0d7d-00bb-4b93-8a7e-1ec196a9b074" />
