### PR TITLE
✨Feat: QA 게시판 새로고침 API 구현

### DIFF
--- a/src/main/java/com/likelion/server/domain/qa/entity/QaBoard.java
+++ b/src/main/java/com/likelion/server/domain/qa/entity/QaBoard.java
@@ -20,8 +20,8 @@ public class QaBoard {
     @JoinColumn(name = "group_id", nullable = false)
     private Group group;
 
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "quiz_id")
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "quiz_id", unique = true)
     private Quiz quiz;
 
     @Column(nullable = false)

--- a/src/main/java/com/likelion/server/domain/qa/repository/QaCommentRepository.java
+++ b/src/main/java/com/likelion/server/domain/qa/repository/QaCommentRepository.java
@@ -1,6 +1,10 @@
 package com.likelion.server.domain.qa.repository;
 
 import com.likelion.server.domain.qa.entity.QaComment;
+import com.likelion.server.domain.qa.entity.QaPost;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface QaCommentRepository extends JpaRepository<QaComment, Long> {}
+public interface QaCommentRepository extends JpaRepository<QaComment, Long> {
+    // 특정 게시글의 댓글 수 카운트
+    Integer countByPost(QaPost post);
+}

--- a/src/main/java/com/likelion/server/domain/qa/repository/QaPostRepository.java
+++ b/src/main/java/com/likelion/server/domain/qa/repository/QaPostRepository.java
@@ -1,6 +1,12 @@
 package com.likelion.server.domain.qa.repository;
 
+import com.likelion.server.domain.qa.entity.QaBoard;
 import com.likelion.server.domain.qa.entity.QaPost;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface QaPostRepository extends JpaRepository<QaPost, Long> {}
+import java.util.List;
+
+public interface QaPostRepository extends JpaRepository<QaPost, Long> {
+    // 특정 게시판에 속한 게시글 목록 조회
+    List<QaPost> findAllByBoard(QaBoard board);
+}

--- a/src/main/java/com/likelion/server/domain/qa/service/QaService.java
+++ b/src/main/java/com/likelion/server/domain/qa/service/QaService.java
@@ -1,12 +1,9 @@
 package com.likelion.server.domain.qa.service;
 
-import com.likelion.server.domain.qa.web.dto.QaCommentRequest;
-import com.likelion.server.domain.qa.web.dto.QaCommentResponse;
-import com.likelion.server.domain.qa.web.dto.QaPostRequest;
-import com.likelion.server.domain.qa.web.dto.QaPostResponse;
-import com.likelion.server.domain.user.entity.User;
+import com.likelion.server.domain.qa.web.dto.*;
 
 public interface QaService {
     QaPostResponse createPost(QaPostRequest request, Long currentUserId);
     QaCommentResponse createComment(QaCommentRequest request, Long currentUserId);
+    QaBoardRefreshResponse getBoard(Long quizId);
 }

--- a/src/main/java/com/likelion/server/domain/qa/service/QaServiceImpl.java
+++ b/src/main/java/com/likelion/server/domain/qa/service/QaServiceImpl.java
@@ -8,16 +8,15 @@ import com.likelion.server.domain.qa.exception.QaPostNotFoundException;
 import com.likelion.server.domain.qa.repository.QaBoardRepository;
 import com.likelion.server.domain.qa.repository.QaCommentRepository;
 import com.likelion.server.domain.qa.repository.QaPostRepository;
-import com.likelion.server.domain.qa.web.dto.QaCommentRequest;
-import com.likelion.server.domain.qa.web.dto.QaCommentResponse;
-import com.likelion.server.domain.qa.web.dto.QaPostRequest;
-import com.likelion.server.domain.qa.web.dto.QaPostResponse;
+import com.likelion.server.domain.qa.web.dto.*;
 import com.likelion.server.domain.user.entity.User;
 import com.likelion.server.domain.user.repository.UserRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 @Service
 @Transactional(readOnly = true)
@@ -80,5 +79,28 @@ public class QaServiceImpl implements QaService {
 
         // Return
         return new QaCommentResponse(savedComment);
+    }
+
+    @Override
+    public QaBoardRefreshResponse getBoard(Long quizId) {
+
+        // quiz_id로 QaBoard 조회
+        QaBoard board = qaBoardRepository.findByQuizId(quizId)
+                .orElseThrow(QaNotFoundException::new);
+
+        // board의 모든 QaPost 조회
+        List<QaPost> posts = qaPostRepository.findAllByBoard(board);
+
+        // 각 QaPost를 PostDto로 변환
+        List<QaBoardRefreshResponse.PostDto> postDtos = posts.stream()
+                .map(post -> {
+                    // 각 post의 댓글 수 조회
+                    Integer commentsCount = qaCommentRepository.countByPost(post);
+                    return new QaBoardRefreshResponse.PostDto(post, commentsCount);
+                })
+                .toList();
+
+        // return
+        return new QaBoardRefreshResponse(board, postDtos);
     }
 }

--- a/src/main/java/com/likelion/server/domain/qa/web/controller/QaController.java
+++ b/src/main/java/com/likelion/server/domain/qa/web/controller/QaController.java
@@ -1,18 +1,12 @@
 package com.likelion.server.domain.qa.web.controller;
 
 import com.likelion.server.domain.qa.service.QaService;
-import com.likelion.server.domain.qa.web.dto.QaCommentRequest;
-import com.likelion.server.domain.qa.web.dto.QaCommentResponse;
-import com.likelion.server.domain.qa.web.dto.QaPostRequest;
-import com.likelion.server.domain.qa.web.dto.QaPostResponse;
+import com.likelion.server.domain.qa.web.dto.*;
 import com.likelion.server.global.response.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -39,5 +33,14 @@ public class QaController {
     ) {
         QaCommentResponse data = qaService.createComment(request, userId);
         return SuccessResponse.created(data);
+    }
+
+    // QA 게시판 새로고침 (게시글/댓글 목록 조회)
+    @GetMapping("/board/{quiz_id}")
+    public SuccessResponse<QaBoardRefreshResponse> getBoard(
+            @PathVariable("quiz_id") Long quizId
+    ) {
+        QaBoardRefreshResponse data = qaService.getBoard(quizId);
+        return SuccessResponse.ok(data);
     }
 }

--- a/src/main/java/com/likelion/server/domain/qa/web/controller/QaController.java
+++ b/src/main/java/com/likelion/server/domain/qa/web/controller/QaController.java
@@ -5,7 +5,6 @@ import com.likelion.server.domain.qa.web.dto.QaCommentRequest;
 import com.likelion.server.domain.qa.web.dto.QaCommentResponse;
 import com.likelion.server.domain.qa.web.dto.QaPostRequest;
 import com.likelion.server.domain.qa.web.dto.QaPostResponse;
-import com.likelion.server.domain.user.entity.User;
 import com.likelion.server.global.response.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/likelion/server/domain/qa/web/dto/QaBoardRefreshResponse.java
+++ b/src/main/java/com/likelion/server/domain/qa/web/dto/QaBoardRefreshResponse.java
@@ -1,0 +1,44 @@
+package com.likelion.server.domain.qa.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.likelion.server.domain.qa.entity.QaBoard;
+import com.likelion.server.domain.qa.entity.QaPost;
+import com.likelion.server.domain.user.entity.User;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+public record QaBoardRefreshResponse(
+        @JsonProperty("board_id") Long boardId,
+        List<PostDto> posts
+) {
+    public record PostDto(
+            Long id,
+            String title,
+            UserDto user,
+            @JsonProperty("comments_count") Integer commentsCount, // "comments_count": 3
+            @JsonProperty("created_at") String createdAt
+    ) {
+        public PostDto(QaPost post, Integer commentsCount) {
+            this(
+                    post.getId(),
+                    post.getTitle(),
+                    new UserDto(post.getWriter()),
+                    commentsCount,
+                    post.getCreatedAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+            );
+        }
+    }
+
+    public record UserDto(
+            String nickname
+    ) {
+        public UserDto(User user) {
+            this(user.getNickname());
+        }
+    }
+
+    public QaBoardRefreshResponse(QaBoard board, List<PostDto> postDtos) {
+        this(board.getId(), postDtos);
+    }
+}


### PR DESCRIPTION
## 🔍 관련 이슈
<!--
- close #123
-->
- close #30 

<br>

## ✅ 작업 분류
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
1. quiz_id로 QA 게시판을 조회하는 GET /qa/board/{quiz_id} API를 구현했습니다.
2. 자유 QA게시판이 사라짐에 따라 quiz 필드 연관관계를 @ManyToOne에서 @OneToOne으로 수정했습니다.
3. 게시판 조회 로직에 필요한 리포지토리 메서드를 추가했습니다.
4. API 응답을 위한 QaBoardRefreshResponse DTO를 정의했습니다.
5. QaService 및 QaServiceImpl에 게시판과 게시글, 댓글 수를 조합하는 getBoard 비즈니스 로직을 구현했습니다.
6. QaController에 해당 API 엔드포인트를 추가했습니다.

<br>

## 👥 전달사항
<!--
1. User 도메인 구조를 변경하였습니다.
2. User 도메인 사용자 닉네임 필드를 username -> nickname으로 변경하였습니다.
-->

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
<img width="762" height="923" alt="image" src="https://github.com/user-attachments/assets/3eebdc11-1c39-4688-8591-17067c3a9bec" />
