### PR TITLE
✨ Feat: 퀴즈 생성 시 객관식 항목 구현

### DIFF
--- a/src/main/java/com/likelion/server/domain/quiz/entity/QuizOption.java
+++ b/src/main/java/com/likelion/server/domain/quiz/entity/QuizOption.java
@@ -5,6 +5,7 @@ import lombok.*;
 
 @Entity
 @Getter
+@Setter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
@@ -15,7 +16,7 @@ public class QuizOption {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "question_id")
+    @JoinColumn(name = "question_id", nullable = false)
     private QuizQuestion question;
 
     private String optionText;

--- a/src/main/java/com/likelion/server/domain/quiz/entity/QuizQuestion.java
+++ b/src/main/java/com/likelion/server/domain/quiz/entity/QuizQuestion.java
@@ -4,6 +4,9 @@ import com.likelion.server.domain.quiz.entity.enums.Type;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
@@ -29,6 +32,15 @@ public class QuizQuestion {
 
     @Column(columnDefinition = "TEXT")
     private String explanation;
+
+    @OneToMany(mappedBy = "question", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<QuizOption> options = new ArrayList<>();
+
+    public void addOption(QuizOption option) {
+        options.add(option);
+        option.setQuestion(this);
+    }
 
 
 }

--- a/src/main/java/com/likelion/server/domain/quiz/entity/enums/Difficulty.java
+++ b/src/main/java/com/likelion/server/domain/quiz/entity/enums/Difficulty.java
@@ -1,5 +1,22 @@
 package com.likelion.server.domain.quiz.entity.enums;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
 public enum Difficulty {
-    상, 중, 하
+    상("상"), 중("중"), 하("하");
+
+    private final String korean;
+
+    public static Difficulty fromKorean(String value) {
+        return switch (value) {
+            case "상" -> 상;
+            case "중" -> 중;
+            case "하" -> 하;
+            default -> throw new IllegalArgumentException("잘못된 난이도 값: " + value);
+        };
+    }
 }
+

--- a/src/main/java/com/likelion/server/domain/quiz/service/QuizPromptBuilder.java
+++ b/src/main/java/com/likelion/server/domain/quiz/service/QuizPromptBuilder.java
@@ -13,52 +13,61 @@ import org.springframework.stereotype.Component;
 @Component
 public class QuizPromptBuilder {
 
-    public String build(String pdfContent, CreateQuizRequest req, String pdfTitle) {
+    String build(String pdfText, CreateQuizRequest req, String pdfTitle) {
         return String.format("""
-        당신은 대학생을 위한 학습용 퀴즈를 만들어주는 AI 교사입니다.
-        오직 아래의 PDF 내용 안에서만 문제를 출제해야 합니다.
-        외부 지식은 절대 사용하지 마세요.
+        당신은 대학생을 위한 학습용 퀴즈를 만드는 AI 교사입니다.
+        오직 아래의 PDF 내용 안에서만 문제를 출제하세요. 외부 지식은 절대 사용하지 마세요.
 
         🎯 목표:
-        PDF 내용을 기반으로 %d개의 퀴즈 문제를 생성하세요.
+        PDF 내용을 기반으로 %d개의 문제를 생성하세요.
+        난이도: "%s"
+        문제 유형: %s
 
         🧩 문제 조건:
-        - 난이도는 "%s"입니다.
-        - 문제 유형은 다음 중에서 골라 다양하게 섞어주세요: %s.
-        - 각 문제는 반드시 다음 4개의 속성을 가져야 합니다:
-          • question : 문제 본문 (학생이 답변해야 할 질문)
-          • answer : 정답
-          • type : 문제 유형 (OX / 객관식 / 단답형)
-          • explanation : 간단한 해설 (정답 이유나 추가 설명)
-        - 모든 문제는 아래 JSON 형식으로만 출력하세요.
-        - 설명, 인사말, 추가 텍스트 없이 JSON 배열만 출력해야 합니다.
+        - 객관식 문제는 반드시 4개의 보기를 포함해야 합니다.
+        - 객관식 문제는 JSON 내에 "options" 배열을 포함해야 합니다.
+        - 단답형 문제는 짧은 문장으로 정답을 제시합니다.
+        - OX 문제는 정답이 반드시 "O" 또는 "X" 중 하나여야 합니다.
+        - 모든 문제는 PDF의 내용을 정확히 반영해야 합니다.
 
-        📘 출력 예시 (정확히 이 형식으로만 출력하세요):
+        ⚙️ 출력 형식 (JSON 배열만 출력하세요):
         [
           {
-            "question": "4호선톤 프로젝트의 주요 기술 스택은 무엇인가?",
-            "answer": "Django",
+            "question": "주문과 상품의 관계는?",
             "type": "객관식",
-            "explanation": "Django는 Python 기반 백엔드 프레임워크입니다."
+            "options": ["1. 일대다", "2. 다대다", "3. 일대일", "4. 다대일"],
+            "answer": "2",
+            "explanation": "주문과 상품은 다대다 관계이며, 이를 주문상품 엔티티로 풀었다."
           },
           {
-            "question": "4호선톤은 협업 중심의 프로젝트이다. (O/X)",
-            "answer": "O",
+            "question": "회원은 여러 상품을 주문할 수 있다. (O/X)",
             "type": "OX",
-            "explanation": "팀 단위 협업이 핵심인 프로젝트입니다."
+            "answer": "O",
+            "explanation": "회원과 주문은 일대다 관계다."
+          },
+          {
+            "question": "상품의 종류는?",
+            "type": "단답형",
+            "answer": "도서, 음반, 영화",
+            "explanation": "상품은 세 가지 종류로 구분된다."
           }
         ]
 
         ⚖️ 난이도 기준:
-        - 상: 개념 응용, 문장 해석, 세부적 내용 이해가 필요한 문제
-        - 중: 핵심 개념, 원리, 주요 내용을 직접적으로 묻는 문제
-        - 하: 정의, 용어, 단순 사실을 확인하는 문제
+        - 상: 개념 응용, 세부 내용 이해
+        - 중: 핵심 개념 및 정의
+        - 하: 단순 사실 또는 용어 확인
 
         📄 PDF 제목: %s
-        📑 PDF 내용:
+        📑 PDF 내용 (발췌):
         %s
-    """, req.total_questions(), req.difficulty(),
-                String.join(", ", req.question_types()), pdfTitle, pdfContent);
+        """,
+                req.total_questions(),
+                req.difficulty(),
+                String.join(", ", req.question_types()),
+                pdfTitle,
+                pdfText.substring(0, Math.min(pdfText.length(), 6500))
+        );
     }
 }
 

--- a/src/main/java/com/likelion/server/domain/quiz/service/QuizResponseParser.java
+++ b/src/main/java/com/likelion/server/domain/quiz/service/QuizResponseParser.java
@@ -3,6 +3,7 @@ package com.likelion.server.domain.quiz.service;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.likelion.server.domain.quiz.entity.Quiz;
+import com.likelion.server.domain.quiz.entity.QuizOption;
 import com.likelion.server.domain.quiz.entity.QuizQuestion;
 import com.likelion.server.domain.quiz.entity.enums.Type;
 import org.springframework.stereotype.Component;
@@ -80,6 +81,52 @@ public class QuizResponseParser {
                         .correctAnswer(correctAnswer)
                         .explanation(explanation)
                         .build();
+
+                // 객관식이면 보기 자동 생성
+                if (type == Type.MULTIPLE_CHOICE) {
+                    // AI 응답이 보기 리스트를 제공하는 경우
+                    if (node.has("options")) {
+                        for (JsonNode optionNode : node.get("options")) {
+                            String optionText = optionNode.asText();
+                            QuizOption option = QuizOption.builder()
+                                    .question(question)
+                                    .optionText(optionText)
+                                    .isAnswer(optionText.equals(correctAnswer))
+                                    .build();
+                            question.getOptions().add(option);
+                        }
+                    }
+                    // AI 응답이 보기 배열을 제공하지 않은 경우 (기본 4개 보기 예시)
+                    else {
+                        String[] defaultOptions = {"A", "B", "C", "D"};
+                        for (String opt : defaultOptions) {
+                            QuizOption option = QuizOption.builder()
+                                    .question(question)
+                                    .optionText(opt)
+                                    .isAnswer(false)
+                                    .build();
+                            question.getOptions().add(option);
+                        }
+                    }
+                }
+
+                // OX 문제라면 O, X 보기 자동 추가
+                else if (type == Type.OX) {
+                    QuizOption o = QuizOption.builder()
+                            .question(question)
+                            .optionText("O")
+                            .isAnswer(correctAnswer.equalsIgnoreCase("O"))
+                            .build();
+
+                    QuizOption x = QuizOption.builder()
+                            .question(question)
+                            .optionText("X")
+                            .isAnswer(correctAnswer.equalsIgnoreCase("X"))
+                            .build();
+
+                    question.getOptions().addAll(List.of(o, x));
+                }
+
 
                 questions.add(question);
                 System.out.println("[DEBUG] ✅ 문제 추가됨 → " + questionText);

--- a/src/main/java/com/likelion/server/domain/quiz/service/QuizServiceImpl.java
+++ b/src/main/java/com/likelion/server/domain/quiz/service/QuizServiceImpl.java
@@ -34,26 +34,15 @@ public class QuizServiceImpl implements QuizService {
     private final AiQuizGenerator aiQuizGenerator;
     private final EntityManager em;
 
-    @Override
-    public CreateQuizResponse createQuiz(Long userId, CreateQuizRequest request) {
-
-        // PDF 검증
-        Pdf pdf = pdfRepository.findById(request.pdf_id())
+    // 세부 로직 분리 메서드
+    private Pdf validateAndGetPdf(Long pdfId) {
+        return pdfRepository.findById(pdfId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 PDF를 찾을 수 없습니다."));
+    }
 
-        // 라운드 계산
-        int round = quizRepository.countByPdfId(pdf.getId()) + 1;
-
-        // String → Difficulty enum 변환
-        Difficulty difficulty = switch (request.difficulty()) {
-            case "상" -> Difficulty.상;
-            case "중" -> Difficulty.중;
-            case "하" -> Difficulty.하;
-            default -> throw new IllegalArgumentException("잘못된 난이도 값입니다: " + request.difficulty());
-        };
-
-        // Quiz 생성
-        Quiz quiz = Quiz.builder()
+    private Quiz createQuizEntity(Pdf pdf, CreateQuizRequest request, int round) {
+        Difficulty difficulty = Difficulty.fromKorean(request.difficulty());
+        return Quiz.builder()
                 .pdf(pdf)
                 .round(round)
                 .difficulty(difficulty)
@@ -61,76 +50,54 @@ public class QuizServiceImpl implements QuizService {
                 .totalQuestions(request.total_questions())
                 .title(pdf.getFileName())
                 .build();
-        Quiz savedQuiz = quizRepository.saveAndFlush(quiz);
+    }
 
-        // AI 호출 (동기)
-        List<QuizQuestion> generatedQuestions = aiQuizGenerator.generateQuestions(pdf, quiz, request);
-
-        // 생성된 문제 저장
-        quizQuestionRepository.saveAll(generatedQuestions);
-
-        // QA 게시판 생성
-        QaBoard qaBoard = QaBoard.builder()
+    private QaBoard createQaBoard(Pdf pdf, Quiz quiz) {
+        return QaBoard.builder()
                 .quiz(quiz)
-                .boardName(pdf.getFileName())
+                .boardName(pdf.getFileName() + " Quiz 게시판")
                 .group(pdf.getGroup())
-                .build();
-        qaBoardRepository.save(qaBoard);
-
-        // 응답 생성
-        return CreateQuizResponse.builder()
-                .id(quiz.getId())
-                .pdf_id(pdf.getId())
-                .round(round)
-                .difficulty(Difficulty.valueOf(quiz.getDifficulty().name()))
-                .question_types(request.question_types())
-                .total_questions(quiz.getTotalQuestions())
-                .qa_board(new CreateQuizResponse.QaBoard(
-                        qaBoard.getId(),
-                        qaBoard.getBoardName()
-                ))
                 .build();
     }
 
 
-    // 퀴즈 조회
+    // 1. 퀴즈 생성
+    @Override
+    public CreateQuizResponse createQuiz(Long userId, CreateQuizRequest request) {
+
+        // PDF 검증 및 조회
+        Pdf pdf = validateAndGetPdf(request.pdf_id());
+
+        // 라운드 계산
+        int round = quizRepository.countByPdfId(pdf.getId()) + 1;
+
+        // 퀴즈 생성 및 저장
+        Quiz quiz = createQuizEntity(pdf, request, round);
+        quizRepository.saveAndFlush(quiz);
+
+        // AI 퀴즈 생성
+        List<QuizQuestion> generatedQuestions = aiQuizGenerator.generateQuestions(pdf, quiz, request);
+
+        // 문제 저장 (Cascade 안 쓰는 경우 명시적으로 saveAll)
+        quizQuestionRepository.saveAll(generatedQuestions);
+
+        // QA 게시판 생성
+        QaBoard qaBoard = createQaBoard(pdf, quiz);
+        qaBoardRepository.save(qaBoard);
+
+        // 응답 DTO 변환
+        return CreateQuizResponse.fromEntity(quiz, qaBoard);
+    }
+
+
+    // 2. 퀴즈 조회
     @Override
     public QuizDetailResponse getQuizDetail(Long quizId) {
         Quiz quiz = quizRepository.findById(quizId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 퀴즈를 찾을 수 없습니다."));
-
         List<QuizQuestion> questions = quizQuestionRepository.findAllByQuizId(quizId);
 
-        return QuizDetailResponse.builder()
-                .quiz(new QuizDetailResponse.QuizInfo(
-                        quiz.getId(),
-                        quiz.getPdf().getId(),
-                        quiz.getPdf().getFileName(),
-                        quiz.getDifficulty().name(),
-                        quiz.getRound(),
-                        quiz.getTotalQuestions(),
-                        quiz.getCreatedAt()
-                ))
-                .questions(
-                        questions.stream()
-                                .map(q -> new QuizDetailResponse.QuestionInfo(
-                                        q.getId(),
-                                        convertTypeToKorean(q.getType()),
-                                        q.getQuestionText(),
-                                        q.getCorrectAnswer(),
-                                        q.getExplanation()
-                                ))
-                                .toList()
-                )
-                .build();
-    }
-
-    private String convertTypeToKorean(Type type) {
-        return switch (type) {
-            case OX -> "OX";
-            case MULTIPLE_CHOICE -> "객관식";
-            case SHORT_ANSWER -> "단답형";
-        };
+        return QuizDetailResponse.fromEntities(quiz, questions);
     }
 
 

--- a/src/main/java/com/likelion/server/domain/quiz/web/dto/CreateQuizResponse.java
+++ b/src/main/java/com/likelion/server/domain/quiz/web/dto/CreateQuizResponse.java
@@ -1,23 +1,46 @@
 package com.likelion.server.domain.quiz.web.dto;
 
+import com.likelion.server.domain.qa.entity.QaBoard;
+import com.likelion.server.domain.quiz.entity.Quiz;
 import com.likelion.server.domain.quiz.entity.enums.Difficulty;
 import lombok.Builder;
+import lombok.Getter;
+
 import java.util.List;
 
+@Getter
 @Builder
-public record CreateQuizResponse(
-        Long id,
-        Long pdf_id,
-        Integer round,
-        Difficulty difficulty,
-        List<String> question_types,
-        Integer total_questions,
-        String status,
-        QaBoard qa_board
-) {
+public class CreateQuizResponse {
+    private Long id;
+    private Long pdf_id;
+    private int round;
+    private String difficulty;
+    private List<String> question_types;
+    private int total_questions;
+    private QaBoardInfo qa_board;
+
+    @Getter
     @Builder
-    public record QaBoard(
-            Long board_id,
-            String title
-    ) {}
+    public static class QaBoardInfo {
+        private Long board_id;
+        private String title;
+    }
+
+    public static CreateQuizResponse fromEntity(Quiz quiz, QaBoard qaBoard) {
+        return CreateQuizResponse.builder()
+                .id(quiz.getId())
+                .pdf_id(quiz.getPdf().getId())
+                .round(quiz.getRound())
+                .difficulty(quiz.getDifficulty().name())
+                .question_types(List.of(quiz.getQuestionTypes().split(",")))
+                .total_questions(quiz.getTotalQuestions())
+                .qa_board(
+                        QaBoardInfo.builder()
+                                .board_id(qaBoard.getId())
+                                .title(qaBoard.getBoardName())
+                                .build()
+                )
+                .build();
+    }
 }
+

--- a/src/main/java/com/likelion/server/domain/quiz/web/dto/QuizDetailResponse.java
+++ b/src/main/java/com/likelion/server/domain/quiz/web/dto/QuizDetailResponse.java
@@ -1,5 +1,9 @@
 package com.likelion.server.domain.quiz.web.dto;
 
+import com.likelion.server.domain.quiz.entity.Quiz;
+import com.likelion.server.domain.quiz.entity.QuizOption;
+import com.likelion.server.domain.quiz.entity.QuizQuestion;
+import com.likelion.server.domain.quiz.entity.enums.Type;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
@@ -7,6 +11,7 @@ import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Getter
 @Builder
@@ -17,7 +22,9 @@ public class QuizDetailResponse {
     private QuizInfo quiz;
     private List<QuestionInfo> questions;
 
+    // 퀴즈 기본 정보
     @Getter
+    @Builder
     @AllArgsConstructor
     public static class QuizInfo {
         private Long id;
@@ -27,8 +34,23 @@ public class QuizDetailResponse {
         private int round;
         private int total_questions;
         private LocalDateTime createdAt;
+
+        public static QuizInfo fromEntity(Quiz quiz) {
+            return QuizInfo.builder()
+                    .id(quiz.getId())
+                    .pdf_id(quiz.getPdf().getId())
+                    .title(quiz.getPdf().getFileName())
+                    .difficulty(quiz.getDifficulty().name())
+                    .round(quiz.getRound())
+                    .total_questions(quiz.getTotalQuestions())
+                    .createdAt(quiz.getCreatedAt())
+                    .build();
+        }
     }
 
+
+    // 퀴즈 문제
+    @Builder
     @Getter
     @AllArgsConstructor
     public static class QuestionInfo {
@@ -37,6 +59,53 @@ public class QuizDetailResponse {
         private String question_text;
         private String correct_answer;
         private String explanation;
+        private List<OptionInfo> options;
+
+        public static QuestionInfo fromEntity(QuizQuestion q) {
+            return QuestionInfo.builder()
+                    .id(q.getId())
+                    .type(convertTypeToKorean(q.getType()))
+                    .question_text(q.getQuestionText())
+                    .correct_answer(q.getCorrectAnswer())
+                    .explanation(q.getExplanation())
+                    .options(q.getOptions().stream()
+                            .map(OptionInfo::fromEntity)
+                            .collect(Collectors.toList()))
+                    .build();
+        }
+
+        private static String convertTypeToKorean(Type type) {
+            return switch (type) {
+                case OX -> "OX";
+                case MULTIPLE_CHOICE -> "객관식";
+                case SHORT_ANSWER -> "단답형";
+            };
+        }
+    }
+
+    // 객관식 보기
+    @Getter
+    @Builder
+    public static class OptionInfo {
+        private Long id;
+        private String option_text;
+
+        public static OptionInfo fromEntity(QuizOption o) {
+            return OptionInfo.builder()
+                    .id(o.getId())
+                    .option_text(o.getOptionText())
+                    .build();
+        }
+    }
+
+    // 전체 DTO 변환 (Service에서 바로 호출)
+    public static QuizDetailResponse fromEntities(Quiz quiz, List<QuizQuestion> questions) {
+        return QuizDetailResponse.builder()
+                .quiz(QuizInfo.fromEntity(quiz))
+                .questions(questions.stream()
+                        .map(QuestionInfo::fromEntity)
+                        .collect(Collectors.toList()))
+                .build();
     }
 }
 


### PR DESCRIPTION
## 🔍 관련 이슈
- close #22 

<br>

## ✅ 작업 분류
- [x] 신규 기능
- [x] 기능 수정
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경
- [x] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
  1. 퀴즈 생성 시 객관식도 생성되도록 수정
  2. OX 및 객관식 항목은 options 필드로 항목 추출
  3. response 관련 Service 코드를 DTO로 분할하여 가독성 향상
  4. Difficulty 형 전환 코드를 entity 폴더로 분할하여 가독성 향상
  5. QuizOption, QuizQuestion 을 M2O 관계로 설정하여 Option을 관리

<br>

## 👥 전달사항
현재 객관식은 option_text 필드에 번호 + 객관식 보기 가 함께 나오고 있는데
필요시 번호를 삭제해야할 수도 있음.
<img width="198" height="46" alt="image" src="https://github.com/user-attachments/assets/01077b39-a52a-4f7f-8c38-98aa8e32885e" />
ex) 1. ORDER -> ORDER


<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
<img width="840" height="950" alt="image" src="https://github.com/user-attachments/assets/a4bfe2df-6f16-4447-b23a-4e2cd0bbf75e" />


