### PR TITLE
✨ Feat: 퀴즈 응시 시작 API 구현

### DIFF
--- a/src/main/java/com/likelion/server/domain/quiz/entity/QuizResult.java
+++ b/src/main/java/com/likelion/server/domain/quiz/entity/QuizResult.java
@@ -18,11 +18,11 @@ public class QuizResult extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "quiz_id")
+    @JoinColumn(name = "quiz_id", nullable = false)
     private Quiz quiz;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/likelion/server/domain/quiz/repository/QuizResultRepository.java
+++ b/src/main/java/com/likelion/server/domain/quiz/repository/QuizResultRepository.java
@@ -1,0 +1,9 @@
+package com.likelion.server.domain.quiz.repository;
+
+import com.likelion.server.domain.quiz.entity.QuizResult;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface QuizResultRepository extends JpaRepository<QuizResult, Long> {
+}

--- a/src/main/java/com/likelion/server/domain/quiz/service/QuizResultService.java
+++ b/src/main/java/com/likelion/server/domain/quiz/service/QuizResultService.java
@@ -1,0 +1,36 @@
+package com.likelion.server.domain.quiz.service;
+
+import com.likelion.server.domain.group.entity.Group;
+import com.likelion.server.domain.quiz.entity.Quiz;
+import com.likelion.server.domain.quiz.entity.QuizResult;
+import com.likelion.server.domain.quiz.repository.QuizRepository;
+import com.likelion.server.domain.quiz.repository.QuizResultRepository;
+import com.likelion.server.domain.quiz.web.dto.QuizResultRequest;
+import com.likelion.server.domain.user.entity.User;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class QuizResultService {
+
+    private final QuizResultRepository quizResultRepository;
+    private final QuizRepository quizRepository;
+    private final EntityManager em;
+
+    public QuizResult startQuiz(Long userId, QuizResultRequest request) {
+
+        Quiz quiz = quizRepository.findById(request.quiz_id())
+                .orElseThrow(() -> new IllegalArgumentException("해당 퀴즈를 찾을 수 없습니다."));
+
+        User user = em.getReference(User.class, userId);
+        Group group = quiz.getPdf().getGroup();
+
+        QuizResult quizResult = request.toEntity(quiz, user, group);
+
+        return quizResultRepository.save(quizResult);
+    }
+}

--- a/src/main/java/com/likelion/server/domain/quiz/web/controller/QuizResultController.java
+++ b/src/main/java/com/likelion/server/domain/quiz/web/controller/QuizResultController.java
@@ -1,0 +1,31 @@
+package com.likelion.server.domain.quiz.web.controller;
+
+import com.likelion.server.domain.quiz.service.QuizResultService;
+import com.likelion.server.domain.quiz.web.dto.QuizResultRequest;
+import com.likelion.server.global.response.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/quiz")
+public class QuizResultController {
+
+    private final QuizResultService quizResultService;
+
+    @PostMapping("/start")
+    public SuccessResponse<Map<String, Object>> startQuiz(
+            @AuthenticationPrincipal(expression = "id") Long userId,
+            @RequestBody QuizResultRequest request
+    ) {
+        var result = quizResultService.startQuiz(userId, request);
+
+        return SuccessResponse.ok(Map.of(
+                "message", "퀴즈 응시를 시작합니다.",
+                "quiz_result_id", result.getId()
+        ));
+    }
+}

--- a/src/main/java/com/likelion/server/domain/quiz/web/dto/QuizResultRequest.java
+++ b/src/main/java/com/likelion/server/domain/quiz/web/dto/QuizResultRequest.java
@@ -1,0 +1,22 @@
+package com.likelion.server.domain.quiz.web.dto;
+
+import com.likelion.server.domain.group.entity.Group;
+import com.likelion.server.domain.quiz.entity.Quiz;
+import com.likelion.server.domain.quiz.entity.QuizResult;
+import com.likelion.server.domain.user.entity.User;
+import lombok.Builder;
+
+@Builder
+public record QuizResultRequest(
+        Long quiz_id
+) {
+    public QuizResult toEntity(Quiz quiz, User user, Group group) {
+        return QuizResult.builder()
+                .quiz(quiz)
+                .user(user)
+                .group(group)
+                .score(0)
+                .correctCount(0)
+                .build();
+    }
+}


### PR DESCRIPTION
## 🔍 관련 이슈
- close #34 

<br>

## ✅ 작업 분류
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
<!--
  ex) 
  1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴
-->
1. 퀴즈 응시 세션을 시작하고 결과 레코드를 생성한다.

<br>

## 👥 전달사항
1. 현재 유저가 같은 quiz_id로 여러번 결과 레코드를 생성할 수 있는 로직이지만 필요 시 횟수 제한 필요

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
<img width="827" height="680" alt="image" src="https://github.com/user-attachments/assets/8d948f03-f55b-45ce-9040-5e1d8cb1f594" />

