### PR TITLE
✨ Feat: 퀴즈 제출 및 채점 API 구현

### DIFF
--- a/src/main/java/com/likelion/server/domain/quiz/entity/QuizResult.java
+++ b/src/main/java/com/likelion/server/domain/quiz/entity/QuizResult.java
@@ -10,7 +10,7 @@ import lombok.*;
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
-@Builder
+@Builder(toBuilder = true)
 public class QuizResult extends BaseEntity {
 
     @Id

--- a/src/main/java/com/likelion/server/domain/quiz/entity/QuizUserAnswer.java
+++ b/src/main/java/com/likelion/server/domain/quiz/entity/QuizUserAnswer.java
@@ -16,11 +16,15 @@ public class QuizUserAnswer {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "question_id")
+    @JoinColumn(name = "quiz_result_id", nullable = false)
+    private QuizResult quizResult;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "question_id", nullable = false)
     private QuizQuestion question;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
     private String userAnswer;

--- a/src/main/java/com/likelion/server/domain/quiz/repository/QuizUserAnswerRepository.java
+++ b/src/main/java/com/likelion/server/domain/quiz/repository/QuizUserAnswerRepository.java
@@ -1,0 +1,9 @@
+package com.likelion.server.domain.quiz.repository;
+
+import com.likelion.server.domain.quiz.entity.QuizUserAnswer;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface QuizUserAnswerRepository extends JpaRepository<QuizUserAnswer, Long> {
+}

--- a/src/main/java/com/likelion/server/domain/quiz/service/QuizSubmitService.java
+++ b/src/main/java/com/likelion/server/domain/quiz/service/QuizSubmitService.java
@@ -1,0 +1,63 @@
+package com.likelion.server.domain.quiz.service;
+
+import com.likelion.server.domain.quiz.entity.*;
+import com.likelion.server.domain.quiz.repository.*;
+import com.likelion.server.domain.quiz.web.dto.QuizSubmitRequest;
+import com.likelion.server.domain.quiz.web.dto.QuizSubmitResponse;
+import com.likelion.server.domain.user.entity.User;
+import jakarta.persistence.EntityManager;
+import lombok.Builder;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class QuizSubmitService {
+
+    private final QuizResultRepository quizResultRepository;
+    private final QuizQuestionRepository quizQuestionRepository;
+    private final QuizUserAnswerRepository quizUserAnswerRepository;
+    private final EntityManager em;
+
+    public QuizSubmitResponse submitQuiz(Long userId, QuizSubmitRequest request) {
+
+        QuizResult result = quizResultRepository.findById(request.quiz_result_id())
+                .orElseThrow(() -> new IllegalArgumentException("해당 퀴즈 결과를 찾을 수 없습니다."));
+        User user = em.getReference(User.class, userId);
+
+        List<QuizQuestion> questions = quizQuestionRepository.findAllByQuizId(request.quiz_id());
+        int totalQuestions = questions.size();
+        int correctCount = 0;
+
+        for (QuizSubmitRequest.Answer ans : request.answers()) {
+            QuizQuestion question = em.getReference(QuizQuestion.class, ans.question_id());
+            boolean isCorrect = checkAnswer(ans.user_answer(), question.getCorrectAnswer());
+
+            QuizUserAnswer userAnswer = ans.toEntity(result, question, user, isCorrect);
+            quizUserAnswerRepository.save(userAnswer);
+
+            if (isCorrect) correctCount++;
+        }
+
+        int score = (int) Math.round((correctCount * 100.0) / totalQuestions);
+
+        // update result
+        result = result.toBuilder()
+                .score(score)
+                .correctCount(correctCount)
+                .build();
+
+        quizResultRepository.save(result);
+
+        return QuizSubmitResponse.fromEntity(result.getId(), score, correctCount, totalQuestions);
+    }
+
+    private boolean checkAnswer(String userAnswer, String correctAnswer) {
+        if (userAnswer == null || correctAnswer == null) return false;
+        return userAnswer.trim().equalsIgnoreCase(correctAnswer.trim());
+    }
+}

--- a/src/main/java/com/likelion/server/domain/quiz/web/controller/QuizSubmitController.java
+++ b/src/main/java/com/likelion/server/domain/quiz/web/controller/QuizSubmitController.java
@@ -1,0 +1,35 @@
+package com.likelion.server.domain.quiz.web.controller;
+
+import com.likelion.server.domain.quiz.service.QuizSubmitService;
+import com.likelion.server.domain.quiz.web.dto.QuizSubmitRequest;
+import com.likelion.server.domain.quiz.web.dto.QuizSubmitResponse;
+import com.likelion.server.global.response.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Map;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/quiz")
+public class QuizSubmitController {
+
+    private final QuizSubmitService quizSubmitService;
+
+    @PostMapping("/submit")
+    public SuccessResponse<?> submitQuiz(
+            @AuthenticationPrincipal(expression = "id") Long userId,
+            @RequestBody QuizSubmitRequest request
+    ) {
+        QuizSubmitResponse response = quizSubmitService.submitQuiz(userId, request);
+        return SuccessResponse.ok(Map.of(
+                "message", "채점이 완료되었습니다.",
+                "result", response
+        ));
+    }
+}
+

--- a/src/main/java/com/likelion/server/domain/quiz/web/dto/QuizSubmitRequest.java
+++ b/src/main/java/com/likelion/server/domain/quiz/web/dto/QuizSubmitRequest.java
@@ -1,0 +1,33 @@
+package com.likelion.server.domain.quiz.web.dto;
+
+import com.likelion.server.domain.quiz.entity.QuizQuestion;
+import com.likelion.server.domain.quiz.entity.QuizResult;
+import com.likelion.server.domain.quiz.entity.QuizUserAnswer;
+import com.likelion.server.domain.user.entity.User;
+import lombok.Builder;
+
+import java.util.List;
+
+@Builder
+public record QuizSubmitRequest(
+        Long quiz_result_id,
+        Long quiz_id,
+        List<Answer> answers
+) {
+    @Builder
+    public record Answer(
+            Long question_id,
+            String type,
+            String user_answer
+    ) {
+        public QuizUserAnswer toEntity(QuizResult result, QuizQuestion question, User user, boolean isCorrect) {
+            return QuizUserAnswer.builder()
+                    .quizResult(result)
+                    .question(question)
+                    .user(user)
+                    .userAnswer(user_answer)
+                    .isCorrect(isCorrect)
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/likelion/server/domain/quiz/web/dto/QuizSubmitResponse.java
+++ b/src/main/java/com/likelion/server/domain/quiz/web/dto/QuizSubmitResponse.java
@@ -1,0 +1,27 @@
+package com.likelion.server.domain.quiz.web.dto;
+
+import lombok.Builder;
+
+@Builder
+public record QuizSubmitResponse(
+        Long quiz_result_id,
+        int score,
+        int correct_count,
+        int total_questions,
+        String status
+) {
+    public static QuizSubmitResponse fromEntity(
+            Long quizResultId,
+            int score,
+            int correctCount,
+            int totalQuestions
+    ) {
+        return QuizSubmitResponse.builder()
+                .quiz_result_id(quizResultId)
+                .score(score)
+                .correct_count(correctCount)
+                .total_questions(totalQuestions)
+                .status("completed")
+                .build();
+    }
+}


### PR DESCRIPTION
## 🔍 관련 이슈
- close #36 

<br>

## ✅ 작업 분류
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
1. user별 정답을 저장하는 테이블을 생성하고 채점 결과를 반환한다.

<br>

## 👥 전달사항
<!--
1. User 도메인 구조를 변경하였습니다.
2. User 도메인 사용자 닉네임 필드를 username -> nickname으로 변경하였습니다.
-->

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
<img width="853" height="829" alt="image" src="https://github.com/user-attachments/assets/3d61787b-4219-43f1-91e8-af189063765f" />

