### PR TITLE
✨Feat: 시험지 + QA 게시판 통합 조회 API 구현

### DIFF
--- a/src/main/java/com/likelion/server/domain/qa/repository/QaCommentRepository.java
+++ b/src/main/java/com/likelion/server/domain/qa/repository/QaCommentRepository.java
@@ -4,7 +4,12 @@ import com.likelion.server.domain.qa.entity.QaComment;
 import com.likelion.server.domain.qa.entity.QaPost;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface QaCommentRepository extends JpaRepository<QaComment, Long> {
     // 특정 게시글의 댓글 수 카운트
     Integer countByPost(QaPost post);
+
+    // 특정 게시글에 속한 모든 댓글 목록 조회
+    List<QaComment> findAllByPost(QaPost post);
 }

--- a/src/main/java/com/likelion/server/domain/quiz/exception/QuizErrorCode.java
+++ b/src/main/java/com/likelion/server/domain/quiz/exception/QuizErrorCode.java
@@ -1,0 +1,16 @@
+package com.likelion.server.domain.quiz.exception;
+
+import com.likelion.server.global.response.code.BaseResponseCode;
+import static com.likelion.server.global.constant.StaticValue.NOT_FOUND;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public enum QuizErrorCode implements BaseResponseCode {
+    QUIZ_NOT_FOUND("QUIZ_404_NOT_FOUND", NOT_FOUND, "해당 ID의 퀴즈를 찾을 수 없습니다.");
+
+    private final String code;
+    private final int httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/likelion/server/domain/quiz/exception/QuizNotFoundException.java
+++ b/src/main/java/com/likelion/server/domain/quiz/exception/QuizNotFoundException.java
@@ -1,0 +1,7 @@
+package com.likelion.server.domain.quiz.exception;
+
+import com.likelion.server.global.exception.BaseException;
+
+public class QuizNotFoundException extends BaseException {
+    public QuizNotFoundException() { super(QuizErrorCode.QUIZ_NOT_FOUND); }
+}

--- a/src/main/java/com/likelion/server/domain/quiz/repository/QuizOptionRepository.java
+++ b/src/main/java/com/likelion/server/domain/quiz/repository/QuizOptionRepository.java
@@ -1,0 +1,14 @@
+package com.likelion.server.domain.quiz.repository;
+
+import com.likelion.server.domain.quiz.entity.QuizOption;
+import com.likelion.server.domain.quiz.entity.QuizQuestion;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface QuizOptionRepository extends JpaRepository<QuizOption, Long> {
+    // 질문 ID 기준 보기 조회
+    List<QuizOption> findAllByQuestion(QuizQuestion question);
+}

--- a/src/main/java/com/likelion/server/domain/quiz/service/QuizService.java
+++ b/src/main/java/com/likelion/server/domain/quiz/service/QuizService.java
@@ -3,9 +3,15 @@ package com.likelion.server.domain.quiz.service;
 import com.likelion.server.domain.quiz.web.dto.CreateQuizRequest;
 import com.likelion.server.domain.quiz.web.dto.CreateQuizResponse;
 import com.likelion.server.domain.quiz.web.dto.QuizDetailResponse;
+import com.likelion.server.domain.quiz.web.dto.QuizQaResponse;
+import org.springframework.transaction.annotation.Transactional;
 
 public interface QuizService {
     CreateQuizResponse createQuiz(Long userId, CreateQuizRequest request);
 
     QuizDetailResponse getQuizDetail(Long quizId);
+
+    // 3. 시험지+QA 게시판 통합 조회
+    @Transactional(readOnly = true) // 조회이므로 readOnly = true
+    QuizQaResponse getQuizWithQa(Long quizId);
 }

--- a/src/main/java/com/likelion/server/domain/quiz/service/QuizServiceImpl.java
+++ b/src/main/java/com/likelion/server/domain/quiz/service/QuizServiceImpl.java
@@ -3,24 +3,28 @@ package com.likelion.server.domain.quiz.service;
 import com.likelion.server.domain.pdf.entity.Pdf;
 import com.likelion.server.domain.pdf.repository.PdfRepository;
 import com.likelion.server.domain.qa.entity.QaBoard;
+import com.likelion.server.domain.qa.exception.QaNotFoundException;
 import com.likelion.server.domain.qa.repository.QaBoardRepository;
+import com.likelion.server.domain.qa.repository.QaCommentRepository;
+import com.likelion.server.domain.qa.repository.QaPostRepository;
 import com.likelion.server.domain.quiz.entity.Quiz;
 import com.likelion.server.domain.quiz.entity.QuizQuestion;
 import com.likelion.server.domain.quiz.entity.enums.Difficulty;
-import com.likelion.server.domain.quiz.entity.enums.Type;
+import com.likelion.server.domain.quiz.exception.QuizNotFoundException;
+import com.likelion.server.domain.quiz.repository.QuizOptionRepository;
 import com.likelion.server.domain.quiz.repository.QuizRepository;
 import com.likelion.server.domain.quiz.repository.QuizQuestionRepository;
 import com.likelion.server.domain.quiz.web.dto.CreateQuizRequest;
 import com.likelion.server.domain.quiz.web.dto.CreateQuizResponse;
 import com.likelion.server.domain.quiz.web.dto.QuizDetailResponse;
+import com.likelion.server.domain.quiz.web.dto.QuizQaResponse;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
-
-import static com.likelion.server.domain.quiz.entity.enums.Type.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -33,6 +37,10 @@ public class QuizServiceImpl implements QuizService {
     private final QaBoardRepository qaBoardRepository;
     private final AiQuizGenerator aiQuizGenerator;
     private final EntityManager em;
+
+    private final QuizOptionRepository quizOptionRepository;
+    private final QaPostRepository qaPostRepository;
+    private final QaCommentRepository qaCommentRepository;
 
     // 세부 로직 분리 메서드
     private Pdf validateAndGetPdf(Long pdfId) {
@@ -100,5 +108,49 @@ public class QuizServiceImpl implements QuizService {
         return QuizDetailResponse.fromEntities(quiz, questions);
     }
 
+    // 3. 시험지+QA 게시판 통합 조회
+    @Transactional(readOnly = true)
+    @Override
+    public QuizQaResponse getQuizWithQa(Long quizId) {
 
+        // Quiz 조회
+        Quiz quiz = quizRepository.findById(quizId)
+                .orElseThrow(QuizNotFoundException::new);
+
+        // 질문 목록 조회
+        List<QuizQaResponse.QuestionDto> questionDtos = quizQuestionRepository.findAllByQuizId(quizId)
+                .stream()
+                .map(question -> {
+                    // 객관식 보기 목록 조회
+                    List<QuizQaResponse.OptionDto> optionDtos = quizOptionRepository.findAllByQuestion(question)
+                            .stream()
+                            .map(QuizQaResponse.OptionDto::new)
+                            .collect(Collectors.toList());
+
+                    return new QuizQaResponse.QuestionDto(question, optionDtos);
+                })
+                .collect(Collectors.toList());
+
+        QuizQaResponse.QuizDto quizDto = new QuizQaResponse.QuizDto(quiz, questionDtos);
+
+        QaBoard qaBoard = qaBoardRepository.findByQuizId(quizId)
+                .orElseThrow(() -> new QaNotFoundException());
+
+        // 게시글 목록 조회
+        List<QuizQaResponse.PostDto> postDtos = qaPostRepository.findAllByBoard(qaBoard)
+                .stream()
+                .map(post -> {
+                    // 댓글 목록 조회
+                    List<QuizQaResponse.CommentDto> commentDtos = qaCommentRepository.findAllByPost(post)
+                            .stream()
+                            .map(QuizQaResponse.CommentDto::new)
+                            .collect(Collectors.toList());
+
+                    return new QuizQaResponse.PostDto(post, commentDtos);
+                })
+                .collect(Collectors.toList());
+
+        QuizQaResponse.QaBoardDto qaBoardDto = new QuizQaResponse.QaBoardDto(qaBoard, postDtos);
+        return new QuizQaResponse(quizDto, qaBoardDto);
+    }
 }

--- a/src/main/java/com/likelion/server/domain/quiz/web/controller/QuizController.java
+++ b/src/main/java/com/likelion/server/domain/quiz/web/controller/QuizController.java
@@ -4,6 +4,7 @@ import com.likelion.server.domain.quiz.service.QuizService;
 import com.likelion.server.domain.quiz.web.dto.CreateQuizRequest;
 import com.likelion.server.domain.quiz.web.dto.CreateQuizResponse;
 import com.likelion.server.domain.quiz.web.dto.QuizDetailResponse;
+import com.likelion.server.domain.quiz.web.dto.QuizQaResponse;
 import com.likelion.server.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -33,6 +34,15 @@ public class QuizController {
             @PathVariable("quiz_id") Long quizId
     ) {
         QuizDetailResponse data = quizService.getQuizDetail(quizId);
+        return SuccessResponse.ok(data);
+    }
+
+    // 시험지+QA 게시판 통합 조회
+    @GetMapping("/{quiz_id}/qa-room")
+    public SuccessResponse<QuizQaResponse> getQuizWithQaRoom(
+            @PathVariable("quiz_id") Long quizId
+    ) {
+        QuizQaResponse data = quizService.getQuizWithQa(quizId);
         return SuccessResponse.ok(data);
     }
 }

--- a/src/main/java/com/likelion/server/domain/quiz/web/dto/QuizQaResponse.java
+++ b/src/main/java/com/likelion/server/domain/quiz/web/dto/QuizQaResponse.java
@@ -1,0 +1,129 @@
+package com.likelion.server.domain.quiz.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.likelion.server.domain.qa.entity.QaBoard;
+import com.likelion.server.domain.qa.entity.QaComment;
+import com.likelion.server.domain.qa.entity.QaPost;
+import com.likelion.server.domain.quiz.entity.Quiz;
+import com.likelion.server.domain.quiz.entity.QuizOption;
+import com.likelion.server.domain.quiz.entity.QuizQuestion;
+import com.likelion.server.domain.user.entity.User;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+public record QuizQaResponse(
+        QuizDto quiz,
+        @JsonProperty("qa_board") QaBoardDto qaBoard
+) {
+    public record QuizDto(
+            Long id,
+            String title,
+            String difficulty,
+            Integer round,
+            @JsonProperty("total_questions") Integer totalQuestions,
+            @JsonProperty("group_name") String groupName,
+            List<QuestionDto> questions
+    ) {
+        public QuizDto(Quiz quiz, List<QuestionDto> questions) {
+            this(
+                    quiz.getId(),
+                    quiz.getTitle(),
+                    quiz.getDifficulty().getKorean(),
+                    quiz.getRound(),
+                    quiz.getTotalQuestions(),
+                    quiz.getPdf().getGroup().getName(),
+                    questions
+            );
+        }
+    }
+
+    public record QuestionDto(
+            Long id,
+            String type,
+            @JsonProperty("question_text") String questionText,
+            @JsonProperty("correct_answer") String correctAnswer,
+            String explanation,
+            List<OptionDto> options
+    ) {
+        public QuestionDto(QuizQuestion question, List<OptionDto> options) {
+            this(
+                    question.getId(),
+                    question.getType().toString(),
+                    question.getQuestionText(),
+                    question.getCorrectAnswer(),
+                    question.getExplanation(),
+                    (options == null || options.isEmpty()) ? null : options
+            );
+        }
+    }
+
+    public record OptionDto(
+            Long id,
+            @JsonProperty("option_text") String optionText
+    ) {
+        public OptionDto(QuizOption option) {
+            this(option.getId(), option.getOptionText()); // QuizOption
+        }
+    }
+
+    public record QaBoardDto(
+            @JsonProperty("board_id") Long boardId,
+            @JsonProperty("board_title") String boardTitle,
+            @JsonProperty("board_type") String boardType,
+            List<PostDto> posts
+    ) {
+        public QaBoardDto(QaBoard board, List<PostDto> posts) {
+            this(
+                    board.getId(),
+                    board.getBoardName(),
+                    "시험지", // 예시의 "시험지" 타입
+                    posts
+            );
+        }
+    }
+
+    public record PostDto(
+            Long id,
+            String title,
+            UserNicknameDto user,
+            String content,
+            @JsonProperty("created_at") String createdAt,
+            List<CommentDto> comments
+    ) {
+        public PostDto(QaPost post, List<CommentDto> comments) {
+            this(
+                    post.getId(),
+                    post.getTitle(),
+                    new UserNicknameDto(post.getWriter()),
+                    post.getContent(),
+                    post.getCreatedAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
+                    comments
+            );
+        }
+    }
+
+    public record CommentDto(
+            Long id,
+            UserNicknameDto user,
+            String content,
+            @JsonProperty("created_at") String createdAt
+    ) {
+        public CommentDto(QaComment comment) {
+            this(
+                    comment.getId(),
+                    new UserNicknameDto(comment.getUser()),
+                    comment.getContent(),
+                    comment.getCreatedAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+            );
+        }
+    }
+
+    public record UserNicknameDto(
+            String nickname
+    ) {
+        public UserNicknameDto(User user) {
+            this(user.getNickname());
+        }
+    }
+}


### PR DESCRIPTION
## 🔍 관련 이슈
<!--
- close #123
-->
- close #31 

<br>

## ✅ 작업 분류
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
1. 시험지와 QA 게시판 데이터를 한 번에 조회하는 GET /quiz/{quiz_id}/qa-room API를 구현했습니다.
2. quiz_id 조회 실패 시 커스텀 예외를 반환하도록 예외를 추가했습니다.
3. API 명세서에 맞춘 응답 DTO를 정의했습니다.
4. QuizOptionRepository를 새로 추가하고 QaCommentRepository를 수정하여 질문별 보기, 게시글별 댓글 목록을 조회하는 메서드를 추가했습니다.
5. QuizServiceImpl에 퀴즈, 질문, 보기, QA 게시판, 게시글, 댓글 데이터를 모두 조합하는 getQuizWithQa 비즈니스 로직을 구현했습니다.
6. QuizController에 해당 API 엔드포인트를 추가했습니다.

<br>

## 👥 전달사항
<!--
1. User 도메인 구조를 변경하였습니다.
2. User 도메인 사용자 닉네임 필드를 username -> nickname으로 변경하였습니다.
-->

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
<img width="747" height="1236" alt="image" src="https://github.com/user-attachments/assets/8e40ed75-d321-4070-a1e4-fa4cb92f06cd" />
