### PR TITLE
✨Feat: 홈화면 조회 API 구현

### DIFF
--- a/src/main/java/com/likelion/server/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/likelion/server/domain/group/repository/GroupMemberRepository.java
@@ -1,8 +1,16 @@
 package com.likelion.server.domain.group.repository;
 
+import com.likelion.server.domain.group.entity.Group;
 import com.likelion.server.domain.group.entity.Member;
+import com.likelion.server.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
 
 public interface GroupMemberRepository extends JpaRepository<Member, Long> {
     boolean existsByGroupIdAndUserId(Long groupId, Long userId);
+
+    List<Member> findAllByUser(User user);
+
+    Integer countByGroup(Group group);
 }

--- a/src/main/java/com/likelion/server/domain/quiz/repository/QuizRepository.java
+++ b/src/main/java/com/likelion/server/domain/quiz/repository/QuizRepository.java
@@ -1,8 +1,13 @@
 package com.likelion.server.domain.quiz.repository;
 
+import com.likelion.server.domain.group.entity.Group;
 import com.likelion.server.domain.quiz.entity.Quiz;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface QuizRepository extends JpaRepository<Quiz, Long> {
     int countByPdfId(Long pdfId);
+
+    List<Quiz> findAllByGroup(Group group);
 }

--- a/src/main/java/com/likelion/server/domain/quiz/repository/QuizResultRepository.java
+++ b/src/main/java/com/likelion/server/domain/quiz/repository/QuizResultRepository.java
@@ -1,9 +1,14 @@
 package com.likelion.server.domain.quiz.repository;
 
+import com.likelion.server.domain.quiz.entity.Quiz;
 import com.likelion.server.domain.quiz.entity.QuizResult;
+import com.likelion.server.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface QuizResultRepository extends JpaRepository<QuizResult, Long> {
+    Optional<QuizResult> findByUserAndQuiz(User user, Quiz quiz);
 }

--- a/src/main/java/com/likelion/server/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/likelion/server/domain/user/exception/UserErrorCode.java
@@ -1,0 +1,19 @@
+package com.likelion.server.domain.user.exception;
+
+import com.likelion.server.global.response.code.BaseResponseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import static com.likelion.server.global.constant.StaticValue.*;
+
+@Getter
+@AllArgsConstructor
+public enum UserErrorCode implements BaseResponseCode {
+    USER_404_NOT_FOUND("USER_404_NOT_FOUND", NOT_FOUND, "해당 ID의 사용자를 찾을 수 없습니다."),
+    USER_NICKNAME_DUPLICATED("USER_409_NICKNAME_DUPLICATED", CONFLICT, "이미 존재하는 닉네임입니다."),
+    USER_PASSWORD_MISMATCH("USER_400_PASSWORD_MISMATCH", BAD_REQUEST, "비밀번호가 일치하지 않습니다.");
+
+    private final String code;
+    private final int httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/likelion/server/domain/user/exception/UserNicknameDuplicatedException.java
+++ b/src/main/java/com/likelion/server/domain/user/exception/UserNicknameDuplicatedException.java
@@ -1,0 +1,9 @@
+package com.likelion.server.domain.user.exception;
+
+import com.likelion.server.global.exception.BaseException;
+
+public class UserNicknameDuplicatedException extends BaseException {
+    public UserNicknameDuplicatedException() {
+        super(UserErrorCode.USER_NICKNAME_DUPLICATED);
+    }
+}

--- a/src/main/java/com/likelion/server/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/likelion/server/domain/user/exception/UserNotFoundException.java
@@ -1,0 +1,9 @@
+package com.likelion.server.domain.user.exception;
+
+import com.likelion.server.global.exception.BaseException;
+
+public class UserNotFoundException extends BaseException {
+    public UserNotFoundException() {
+        super(UserErrorCode.USER_404_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/likelion/server/domain/user/exception/UserPasswordMismatchException.java
+++ b/src/main/java/com/likelion/server/domain/user/exception/UserPasswordMismatchException.java
@@ -1,0 +1,9 @@
+package com.likelion.server.domain.user.exception;
+
+import com.likelion.server.global.exception.BaseException;
+
+public class UserPasswordMismatchException extends BaseException {
+    public UserPasswordMismatchException() {
+        super(UserErrorCode.USER_PASSWORD_MISMATCH);
+    }
+}

--- a/src/main/java/com/likelion/server/domain/user/service/UserService.java
+++ b/src/main/java/com/likelion/server/domain/user/service/UserService.java
@@ -2,10 +2,10 @@ package com.likelion.server.domain.user.service;
 
 import com.likelion.server.domain.user.web.dto.*;
 
-import java.util.Map;
-
 public interface UserService {
     UserResponse signup(SignupRequest request); // 회원가입
 
     LoginResponse login(LoginRequest request); // 로그인
+
+    HomeResponse getHome(Long userId); // 홈화면
 }

--- a/src/main/java/com/likelion/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/likelion/server/domain/user/service/UserServiceImpl.java
@@ -1,15 +1,28 @@
 package com.likelion.server.domain.user.service;
 
+import com.likelion.server.domain.group.entity.Group;
+import com.likelion.server.domain.group.entity.Member;
+import com.likelion.server.domain.group.repository.GroupMemberRepository;
+import com.likelion.server.domain.qa.entity.QaBoard;
+import com.likelion.server.domain.qa.repository.QaBoardRepository;
+import com.likelion.server.domain.quiz.entity.Quiz;
+import com.likelion.server.domain.quiz.entity.QuizResult;
+import com.likelion.server.domain.quiz.repository.QuizRepository;
+import com.likelion.server.domain.quiz.repository.QuizResultRepository;
 import com.likelion.server.domain.user.entity.User;
+import com.likelion.server.domain.user.exception.UserNicknameDuplicatedException;
+import com.likelion.server.domain.user.exception.UserPasswordMismatchException;
+import com.likelion.server.domain.user.exception.UserNotFoundException;
 import com.likelion.server.domain.user.repository.UserRepository;
 import com.likelion.server.domain.user.web.dto.*;
 import com.likelion.server.global.jwt.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
+import java.util.stream.Collectors;
 
 /**
  * 회원가입 / 로그인 비즈니스 로직
@@ -22,17 +35,22 @@ public class UserServiceImpl implements UserService {
     private final PasswordEncoder passwordEncoder;
     private final JwtTokenProvider jwtTokenProvider;
 
-    //1. 회원가입
+    private final GroupMemberRepository memberRepository;
+    private final QuizRepository quizRepository;
+    private final QaBoardRepository qaBoardRepository;
+    private final QuizResultRepository quizResultRepository;
+
+    // 회원가입
     @Override
     public UserResponse signup(SignupRequest request) {
         // 중복 닉네임 검사
         if (userRepository.existsByNickname(request.getNickname())) {
-            throw new IllegalArgumentException("이미 존재하는 닉네임입니다.");
+            throw new UserNicknameDuplicatedException();
         }
 
         // 비밀번호 일치 검사
         if (!request.getPassword().equals(request.getPasswordCheck())) {
-            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+            throw new UserPasswordMismatchException();
         }
 
         // 유저 생성 및 저장
@@ -47,14 +65,14 @@ public class UserServiceImpl implements UserService {
     }
 
 
-    //2. 로그인
+    // 로그인
     @Override
     public LoginResponse login(LoginRequest request) {
         User user = userRepository.findByNickname(request.getNickname())
-                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 닉네임입니다."));
+                .orElseThrow(UserNotFoundException::new);
 
         if (!passwordEncoder.matches(request.getPassword(), user.getPassword())) {
-            throw new IllegalArgumentException("비밀번호가 일치하지 않습니다.");
+            throw new UserPasswordMismatchException();
         }
 
         // Access / Refresh Token 생성
@@ -72,5 +90,78 @@ public class UserServiceImpl implements UserService {
                 refreshToken,
                 new UserResponse(user.getId(), user.getNickname())
         );
+    }
+
+    // 홈화면 조회
+    @Transactional(readOnly = true)
+    @Override
+    public HomeResponse getHome(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        // 사용자가 속한 모든 그룹 조회
+        List<Group> userGroups = memberRepository.findAllByUser(user)
+                .stream()
+                .map(Member::getGroup)
+                .toList();
+
+        // [groups] DTO 목록 생성 (Quiz Room)
+        List<HomeResponse.GroupDto> groupDtos = userGroups.stream()
+                .map(group -> {
+                    Integer memberCount = memberRepository.countByGroup(group);
+                    return new HomeResponse.GroupDto(group, memberCount);
+                })
+                .collect(Collectors.toList());
+
+        // [exam_schedule] DTO 목록 생성 (Exam Date)
+        List<HomeResponse.ExamScheduleDto> scheduleDtos = userGroups.stream()
+                .filter(group -> group.getExamDate() != null && !group.getExamDate().isEmpty())
+                .map(HomeResponse.ExamScheduleDto::new)
+                .collect(Collectors.toList());
+
+        // [qa_board] DTO 목록 생성 (Q&A 게시판)
+        List<HomeResponse.QaBoardDto> qaBoardDtos = new ArrayList<>();
+
+        // 사용자가 속한 그룹의 모든 퀴즈를 조회
+        List<Quiz> allQuizzes = userGroups.stream()
+                .flatMap(group -> quizRepository.findAllByGroup(group).stream())
+                .toList();
+
+        // 각 퀴즈를 순회하며 QA게시판과진행률(Progress) 찾기
+        for (Quiz quiz : allQuizzes) {
+            Optional<QaBoard> qaBoardOpt = qaBoardRepository.findByQuizId(quiz.getId());
+
+            if (qaBoardOpt.isPresent()) {
+                QaBoard qaBoard = qaBoardOpt.get();
+
+                // 퀴즈에 대한 점수(QuizResult) 조회
+                Optional<QuizResult> resultOpt = quizResultRepository.findByUserAndQuiz(user, quiz);
+
+                String progress = calculateProgress(user, quiz);
+
+                qaBoardDtos.add(new HomeResponse.QaBoardDto(qaBoard, progress));
+            }
+        }
+
+        // return
+        return new HomeResponse(groupDtos, qaBoardDtos, scheduleDtos);
+    }
+
+    // progress 계산 메서드
+    private String calculateProgress(User user, Quiz quiz) {
+        // 퀴즈에 대한 점수(QuizResult) 조회
+        Optional<QuizResult> resultOpt = quizResultRepository.findByUserAndQuiz(user, quiz);
+
+        int total = (quiz.getTotalQuestions() != null) ? quiz.getTotalQuestions() : 0;
+
+        if (resultOpt.isPresent() && total > 0) {
+            QuizResult result = resultOpt.get();
+            int correct = result.getCorrectCount();
+            long percent = Math.round((double) correct * 100 / total);
+            return String.format("%d/%d (%d%%)", correct, total, percent); // "19/20 (95%)"
+        } else {
+            // 퀴즈를 안 풀었거나, totalQuestions가 0 또는 null인 경우
+            return String.format("0/%d (0%%)", total);
+        }
     }
 }

--- a/src/main/java/com/likelion/server/domain/user/web/controller/UserController.java
+++ b/src/main/java/com/likelion/server/domain/user/web/controller/UserController.java
@@ -1,0 +1,24 @@
+package com.likelion.server.domain.user.web.controller;
+
+import com.likelion.server.domain.user.service.UserService;
+import com.likelion.server.domain.user.web.dto.HomeResponse;
+import com.likelion.server.global.response.SuccessResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    @GetMapping("/home") //
+    public SuccessResponse<HomeResponse> getHome(
+            @AuthenticationPrincipal(expression = "id") Long userId
+    ) {
+        HomeResponse data = userService.getHome(userId);
+        return SuccessResponse.ok(data);
+    }
+}

--- a/src/main/java/com/likelion/server/domain/user/web/dto/HomeResponse.java
+++ b/src/main/java/com/likelion/server/domain/user/web/dto/HomeResponse.java
@@ -1,0 +1,56 @@
+package com.likelion.server.domain.user.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.likelion.server.domain.group.entity.Group;
+import com.likelion.server.domain.qa.entity.QaBoard;
+
+import java.util.List;
+
+public record HomeResponse(
+        List<GroupDto> groups,
+        @JsonProperty("qa_board") List<QaBoardDto> qaBoard,
+        @JsonProperty("exam_schedule") List<ExamScheduleDto> examSchedule
+) {
+
+    public record GroupDto(
+            Long id,
+            String name,
+            @JsonProperty("exam_date") String examDate,
+            @JsonProperty("member_count") Integer memberCount
+    ) {
+        public GroupDto(Group group, Integer memberCount) {
+            this(
+                    group.getId(),
+                    group.getName(),
+                    group.getExamDate(),
+                    memberCount
+            );
+        }
+    }
+
+    public record QaBoardDto(
+            Long id,
+            String title,
+            String progress
+    ) {
+        public QaBoardDto(QaBoard qaBoard, String progress) {
+            this(
+                    qaBoard.getId(),
+                    qaBoard.getBoardName(),
+                    progress
+            );
+        }
+    }
+
+    public record ExamScheduleDto(
+            @JsonProperty("course_name") String courseName,
+            @JsonProperty("exam_date") String examDate
+    ) {
+        public ExamScheduleDto(Group group) {
+            this(
+                    group.getName(),
+                    group.getExamDate()
+            );
+        }
+    }
+}


### PR DESCRIPTION
## 🔍 관련 이슈
- close #38 

<br>

## ✅ 작업 분류
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
1. 홈 화면(GET /home) API 구현
- 로그인한 사용자의 홈 화면 정보를 조회하는 GET /home API를 구현했습니다.
- user 패키지에 UserController를 새로 생성하여 엔드포인트를 매핑했습니다.
- 서비스로직에 getHome 메서드를 구현하여, 사용자가 속한 그룹(Quiz Room) 목록, QA 게시판 목록 및 퀴즈 정답률(progress), 시험 일정(Exam Date) 정보를 조합하여 반환하도록 했습니다.
- 조회에 필요한 HomeResponse DTO 및 쿼리 메서드를 추가했습니다.

2. User 도메인 예외 처리 리팩토링
- User 도메인의 예외 처리를 표준화하기 위해 커스텀 에러 코드를 추가했습니다.
- UserServiceImpl의 회원가입, 로그인 메서드에서 사용하던 IllegalArgumentException 및 EntityNotFoundException을 모두 커스텀 예외로 교체하여 일관성을 높였습니다.

<br>

## 👥 전달사항
<!--
1. User 도메인 구조를 변경하였습니다.
2. User 도메인 사용자 닉네임 필드를 username -> nickname으로 변경하였습니다.
-->

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
<img width="755" height="854" alt="image" src="https://github.com/user-attachments/assets/5a707f95-aa14-4e65-8507-c71a0e438855" />
