### PR TITLE
✨ Feat: 퀴즈 결과 및 채점 세부 내역 조회 API 구현

### DIFF
--- a/src/main/java/com/likelion/server/domain/quiz/entity/QuizResult.java
+++ b/src/main/java/com/likelion/server/domain/quiz/entity/QuizResult.java
@@ -31,4 +31,19 @@ public class QuizResult extends BaseEntity {
 
     private Integer score;
     private Integer correctCount;
+
+
+    // setter
+    public void setScore(int score) {
+        this.score = score;
+    }
+
+    public void setCorrectCount(int correctCount) {
+        this.correctCount = correctCount;
+    }
+
+    public void updateResult(int score, int correctCount) {
+        this.score = score;
+        this.correctCount = correctCount;
+    }
 }

--- a/src/main/java/com/likelion/server/domain/quiz/exception/QuizDuplicateAnswerException.java
+++ b/src/main/java/com/likelion/server/domain/quiz/exception/QuizDuplicateAnswerException.java
@@ -1,0 +1,9 @@
+package com.likelion.server.domain.quiz.exception;
+
+import com.likelion.server.global.exception.BaseException;
+
+public class QuizDuplicateAnswerException extends BaseException {
+    public QuizDuplicateAnswerException() {
+        super(QuizErrorCode.QUIZ_DUPLICATE_ANSWER);
+    }
+}

--- a/src/main/java/com/likelion/server/domain/quiz/exception/QuizErrorCode.java
+++ b/src/main/java/com/likelion/server/domain/quiz/exception/QuizErrorCode.java
@@ -1,0 +1,22 @@
+package com.likelion.server.domain.quiz.exception;
+
+import com.likelion.server.global.response.code.BaseResponseCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import static com.likelion.server.global.constant.StaticValue.NOT_FOUND;
+import static com.likelion.server.global.constant.StaticValue.BAD_REQUEST;
+
+@Getter
+@AllArgsConstructor
+public enum QuizErrorCode implements BaseResponseCode {
+
+    QUIZ_404_NOT_FOUND("QUIZ_404_NOT_FOUND", NOT_FOUND, "해당 퀴즈를 찾을 수 없습니다."),
+    QUIZ_RESULT_404_NOT_FOUND("QUIZ_RESULT_404_NOT_FOUND", NOT_FOUND, "해당 퀴즈 결과를 찾을 수 없습니다."),
+    QUIZ_INVALID_REQUEST("QUIZ_400_INVALID_REQUEST", BAD_REQUEST, "요청 값이 올바르지 않습니다."),
+    QUIZ_DUPLICATE_ANSWER("QUIZ_400_DUPLICATE_ANSWER", BAD_REQUEST, "이미 응답한 문제입니다.");
+
+    private final String code;
+    private final int httpStatus;
+    private final String message;
+}

--- a/src/main/java/com/likelion/server/domain/quiz/exception/QuizException.java
+++ b/src/main/java/com/likelion/server/domain/quiz/exception/QuizException.java
@@ -1,0 +1,28 @@
+package com.likelion.server.domain.quiz.exception;
+
+import lombok.Getter;
+
+@Getter
+public class QuizException extends RuntimeException {
+
+    private final QuizErrorCode errorCode;
+
+    public QuizException(QuizErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public static final QuizErrorCode QUIZ_NOT_FOUND = new QuizErrorCode("QUIZ_404", "퀴즈를 찾을 수 없습니다.");
+    public static final QuizErrorCode QUIZ_RESULT_NOT_FOUND = new QuizErrorCode("QUIZ_RESULT_404", "퀴즈 결과를 찾을 수 없습니다.");
+
+    @Getter
+    public static class QuizErrorCode {
+        private final String code;
+        private final String message;
+
+        public QuizErrorCode(String code, String message) {
+            this.code = code;
+            this.message = message;
+        }
+    }
+}

--- a/src/main/java/com/likelion/server/domain/quiz/exception/QuizInvalidRequestException.java
+++ b/src/main/java/com/likelion/server/domain/quiz/exception/QuizInvalidRequestException.java
@@ -1,0 +1,9 @@
+package com.likelion.server.domain.quiz.exception;
+
+import com.likelion.server.global.exception.BaseException;
+
+public class QuizInvalidRequestException extends BaseException {
+    public QuizInvalidRequestException() {
+        super(QuizErrorCode.QUIZ_INVALID_REQUEST);
+    }
+}

--- a/src/main/java/com/likelion/server/domain/quiz/exception/QuizNotFoundException.java
+++ b/src/main/java/com/likelion/server/domain/quiz/exception/QuizNotFoundException.java
@@ -1,0 +1,9 @@
+package com.likelion.server.domain.quiz.exception;
+
+import com.likelion.server.global.exception.BaseException;
+
+public class QuizNotFoundException extends BaseException {
+    public QuizNotFoundException() {
+        super(QuizErrorCode.QUIZ_404_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/likelion/server/domain/quiz/exception/QuizResultNotFoundException.java
+++ b/src/main/java/com/likelion/server/domain/quiz/exception/QuizResultNotFoundException.java
@@ -1,0 +1,9 @@
+package com.likelion.server.domain.quiz.exception;
+
+import com.likelion.server.global.exception.BaseException;
+
+public class QuizResultNotFoundException extends BaseException {
+    public QuizResultNotFoundException() {
+        super(QuizErrorCode.QUIZ_RESULT_404_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/likelion/server/domain/quiz/repository/QuizUserAnswerRepository.java
+++ b/src/main/java/com/likelion/server/domain/quiz/repository/QuizUserAnswerRepository.java
@@ -2,8 +2,18 @@ package com.likelion.server.domain.quiz.repository;
 
 import com.likelion.server.domain.quiz.entity.QuizUserAnswer;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.util.List;
 
 @Repository
 public interface QuizUserAnswerRepository extends JpaRepository<QuizUserAnswer, Long> {
+
+    @Query("SELECT DISTINCT a FROM QuizUserAnswer a WHERE a.quizResult.id = :quizResultId")
+    List<QuizUserAnswer> findAllByQuizResultId(@Param("quizResultId") Long quizResultId);
+
+    boolean existsByQuizResultIdAndQuestionId(Long quizResultId, Long questionId);
+
 }

--- a/src/main/java/com/likelion/server/domain/quiz/service/QuizResultService.java
+++ b/src/main/java/com/likelion/server/domain/quiz/service/QuizResultService.java
@@ -2,9 +2,14 @@ package com.likelion.server.domain.quiz.service;
 
 import com.likelion.server.domain.group.entity.Group;
 import com.likelion.server.domain.quiz.entity.Quiz;
+import com.likelion.server.domain.quiz.entity.QuizQuestion;
 import com.likelion.server.domain.quiz.entity.QuizResult;
+import com.likelion.server.domain.quiz.entity.QuizUserAnswer;
+import com.likelion.server.domain.quiz.repository.QuizQuestionRepository;
 import com.likelion.server.domain.quiz.repository.QuizRepository;
 import com.likelion.server.domain.quiz.repository.QuizResultRepository;
+import com.likelion.server.domain.quiz.repository.QuizUserAnswerRepository;
+import com.likelion.server.domain.quiz.web.dto.QuizResultDetailResponse;
 import com.likelion.server.domain.quiz.web.dto.QuizResultRequest;
 import com.likelion.server.domain.user.entity.User;
 import jakarta.persistence.EntityManager;
@@ -12,12 +17,16 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 @Transactional
 public class QuizResultService {
 
     private final QuizResultRepository quizResultRepository;
+    private final QuizUserAnswerRepository quizUserAnswerRepository;
+    private final QuizQuestionRepository quizQuestionRepository;
     private final QuizRepository quizRepository;
     private final EntityManager em;
 
@@ -32,5 +41,21 @@ public class QuizResultService {
         QuizResult quizResult = request.toEntity(quiz, user, group);
 
         return quizResultRepository.save(quizResult);
+    }
+
+    public QuizResultDetailResponse getQuizResultDetail(Long userId, Long quizResultId) {
+
+        QuizResult result = quizResultRepository.findById(quizResultId)
+                .orElseThrow(() -> new IllegalArgumentException("해당 퀴즈 결과를 찾을 수 없습니다."));
+
+        if (!result.getUser().getId().equals(userId)) {
+            throw new SecurityException("본인의 결과만 조회할 수 있습니다.");
+        }
+
+        // 사용자 답변 목록 조회
+        List<QuizUserAnswer> answers = quizUserAnswerRepository.findAllByQuizResultId(quizResultId);
+        List<QuizQuestion> allQuestions = quizQuestionRepository.findAllByQuizId(result.getQuiz().getId());
+        return QuizResultDetailResponse.from(result, allQuestions, answers);
+
     }
 }

--- a/src/main/java/com/likelion/server/domain/quiz/service/QuizSubmitService.java
+++ b/src/main/java/com/likelion/server/domain/quiz/service/QuizSubmitService.java
@@ -1,12 +1,12 @@
 package com.likelion.server.domain.quiz.service;
 
 import com.likelion.server.domain.quiz.entity.*;
+import com.likelion.server.domain.quiz.exception.*;
 import com.likelion.server.domain.quiz.repository.*;
 import com.likelion.server.domain.quiz.web.dto.QuizSubmitRequest;
 import com.likelion.server.domain.quiz.web.dto.QuizSubmitResponse;
 import com.likelion.server.domain.user.entity.User;
 import jakarta.persistence.EntityManager;
-import lombok.Builder;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -25,18 +25,28 @@ public class QuizSubmitService {
 
     public QuizSubmitResponse submitQuiz(Long userId, QuizSubmitRequest request) {
 
+        if (request.quiz_result_id() == null || request.quiz_id() == null)
+            throw new QuizInvalidRequestException();
+
         QuizResult result = quizResultRepository.findById(request.quiz_result_id())
-                .orElseThrow(() -> new IllegalArgumentException("해당 퀴즈 결과를 찾을 수 없습니다."));
-        User user = em.getReference(User.class, userId);
+                .orElseThrow(QuizResultNotFoundException::new);
 
         List<QuizQuestion> questions = quizQuestionRepository.findAllByQuizId(request.quiz_id());
+        if (questions.isEmpty()) throw new QuizNotFoundException();
+
+        User user = em.getReference(User.class, userId);
+
         int totalQuestions = questions.size();
         int correctCount = 0;
 
         for (QuizSubmitRequest.Answer ans : request.answers()) {
             QuizQuestion question = em.getReference(QuizQuestion.class, ans.question_id());
-            boolean isCorrect = checkAnswer(ans.user_answer(), question.getCorrectAnswer());
 
+            // 중복 제출 방지
+            if (quizUserAnswerRepository.existsByQuizResultIdAndQuestionId(result.getId(), question.getId()))
+                throw new QuizDuplicateAnswerException();
+
+            boolean isCorrect = checkAnswer(question, ans.user_answer());
             QuizUserAnswer userAnswer = ans.toEntity(result, question, user, isCorrect);
             quizUserAnswerRepository.save(userAnswer);
 
@@ -44,20 +54,27 @@ public class QuizSubmitService {
         }
 
         int score = (int) Math.round((correctCount * 100.0) / totalQuestions);
-
-        // update result
-        result = result.toBuilder()
-                .score(score)
-                .correctCount(correctCount)
-                .build();
-
+        result.setScore(score);
+        result.setCorrectCount(correctCount);
         quizResultRepository.save(result);
 
         return QuizSubmitResponse.fromEntity(result.getId(), score, correctCount, totalQuestions);
     }
 
-    private boolean checkAnswer(String userAnswer, String correctAnswer) {
-        if (userAnswer == null || correctAnswer == null) return false;
-        return userAnswer.trim().equalsIgnoreCase(correctAnswer.trim());
+    private boolean checkAnswer(QuizQuestion question, String userAnswer) {
+        if (userAnswer == null || question.getCorrectAnswer() == null) return false;
+
+        String correct = question.getCorrectAnswer().trim();
+        String user = userAnswer.trim();
+
+        return switch (question.getType()) {
+            case OX -> user.equalsIgnoreCase(correct);
+            case MULTIPLE_CHOICE -> user.equalsIgnoreCase(correct)
+                    || correct.contains(user)
+                    || user.contains(correct);
+            case SHORT_ANSWER -> correct.replaceAll("[^가-힣a-zA-Z0-9]", "")
+                    .equalsIgnoreCase(user.replaceAll("[^가-힣a-zA-Z0-9]", ""));
+            default -> false;
+        };
     }
 }

--- a/src/main/java/com/likelion/server/domain/quiz/web/controller/QuizResultController.java
+++ b/src/main/java/com/likelion/server/domain/quiz/web/controller/QuizResultController.java
@@ -1,6 +1,7 @@
 package com.likelion.server.domain.quiz.web.controller;
 
 import com.likelion.server.domain.quiz.service.QuizResultService;
+import com.likelion.server.domain.quiz.web.dto.QuizResultDetailResponse;
 import com.likelion.server.domain.quiz.web.dto.QuizResultRequest;
 import com.likelion.server.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
@@ -27,5 +28,15 @@ public class QuizResultController {
                 "message", "퀴즈 응시를 시작합니다.",
                 "quiz_result_id", result.getId()
         ));
+    }
+
+
+    @GetMapping("/result/{quiz_result_id}")
+    public SuccessResponse<QuizResultDetailResponse> getQuizResultDetail(
+            @AuthenticationPrincipal(expression = "id") Long userId,
+            @PathVariable("quiz_result_id") Long quizResultId
+    ) {
+        QuizResultDetailResponse data = quizResultService.getQuizResultDetail(userId, quizResultId);
+        return SuccessResponse.ok(data);
     }
 }

--- a/src/main/java/com/likelion/server/domain/quiz/web/dto/QuizDetailResponse.java
+++ b/src/main/java/com/likelion/server/domain/quiz/web/dto/QuizDetailResponse.java
@@ -74,7 +74,7 @@ public class QuizDetailResponse {
                     .build();
         }
 
-        private static String convertTypeToKorean(Type type) {
+        static String convertTypeToKorean(Type type) {
             return switch (type) {
                 case OX -> "OX";
                 case MULTIPLE_CHOICE -> "객관식";

--- a/src/main/java/com/likelion/server/domain/quiz/web/dto/QuizResultDetailResponse.java
+++ b/src/main/java/com/likelion/server/domain/quiz/web/dto/QuizResultDetailResponse.java
@@ -1,0 +1,85 @@
+package com.likelion.server.domain.quiz.web.dto;
+
+import com.likelion.server.domain.quiz.entity.QuizQuestion;
+import com.likelion.server.domain.quiz.entity.QuizResult;
+import com.likelion.server.domain.quiz.entity.QuizUserAnswer;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static com.likelion.server.domain.quiz.web.dto.QuizDetailResponse.QuestionInfo.convertTypeToKorean;
+
+@Builder
+public record QuizResultDetailResponse(
+        QuizResultInfo quiz_result,
+        List<AnswerInfo> answers
+) {
+    @Builder
+    public record QuizResultInfo(
+            Long quiz_id,
+            Integer score,
+            Integer correct_count,
+            Integer total_questions,
+            LocalDateTime created_at
+    ) {}
+
+    @Builder
+    public record AnswerInfo(
+            Long quiz_result_id,
+            Long question_id,
+            String question_text,
+            String type,
+            String explanation,
+            List<QuizDetailResponse.OptionInfo> options,
+            String user_answer,
+            String correct_answer,
+            Boolean is_correct
+    ) {}
+
+    public static QuizResultDetailResponse from(
+            QuizResult result,
+            List<QuizQuestion> allQuestions,
+            List<QuizUserAnswer> answers
+    ) {
+        Map<Long, QuizUserAnswer> answerMap = answers.stream()
+                .collect(Collectors.toMap(a -> a.getQuestion().getId(), a -> a, (a, b) -> a));
+
+        Set<Long> seen = new HashSet<>();
+
+        List<AnswerInfo> answerInfos = allQuestions.stream()
+                .filter(q -> seen.add(q.getId()))
+                .map(q -> {
+                    QuizUserAnswer a = answerMap.get(q.getId());
+                    boolean answered = (a != null);
+
+                    return AnswerInfo.builder()
+                            .quiz_result_id(result.getId())
+                            .question_id(q.getId())
+                            .question_text(q.getQuestionText())
+                            .type(convertTypeToKorean(q.getType()))
+                            .explanation(q.getExplanation())
+                            .options(q.getOptions() == null ? List.of() :
+                                    q.getOptions().stream()
+                                            .map(QuizDetailResponse.OptionInfo::fromEntity)
+                                            .collect(Collectors.toList()))
+                            .user_answer(answered ? a.getUserAnswer() : null)
+                            .correct_answer(q.getCorrectAnswer())
+                            .is_correct(answered && Boolean.TRUE.equals(a.getIsCorrect()))
+                            .build();
+                })
+                .toList();
+
+        return QuizResultDetailResponse.builder()
+                .quiz_result(QuizResultInfo.builder()
+                        .quiz_id(result.getQuiz().getId())
+                        .score(result.getScore())
+                        .correct_count(result.getCorrectCount())
+                        .total_questions(result.getQuiz().getTotalQuestions())
+                        .created_at(result.getCreatedAt())
+                        .build())
+                .answers(answerInfos)
+                .build();
+    }
+}


### PR DESCRIPTION
## 🔍 관련 이슈
- close #37 
<br>

## ✅ 작업 분류
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경
- [x] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
1. 퀴즈 결과 및 채점 세부 내역 조회 API 구현 (quiz/result/{id})
 - QuizResultDetailResponse DTO 작성 (퀴즈 결과 + 각 문항 별 정답/ 사용자 답/ 정오여부/ 선지 목록 포함)
 - QuizResultService 로직 추가 : QuizResult, QuizUserAnswer, QuizQuestion, QuizOption 데이터 조합
 - 답변하지 않은 문항도 결과 목록에 포함 (user_answer = null)
 - <img width="250" height="72" alt="image" src="https://github.com/user-attachments/assets/88b36b8a-bd6a-4fb7-b38a-349f86153136" />
 - 퀴즈별 응답 상세를 한 번의 호출로 조회 가능하도록 구조 단순화

2. 응답 구조 통일화 및 가독성 개선
- AnswerInfo 내부 필드에 type, explanation, options, is_correct 추가
- convertToKorean() 유틸을 활용하여 Enum-> 한글 변환

3. 중복 예외 방지 및 예외 코드 통합
- 존재하지 않는 결과 조회시 예외 반환


<br>

## 👥 전달사항
1. 현재 /quiz/result/{quiz_result_id} API는 JWT 인증 기반으로 작동합니다.
2. 채점 후 저장된 quiz_user_answer 데이터가 존재해야 조회 가능합니다.
3. 같은 문제는 한 번의 제출만 허용됩니다.
4. 프론트엔드 연동 시 quiz_result_id를 submit 응답으로부터 전달받아 사용해주세요.

2. 

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
<img width="855" height="969" alt="image" src="https://github.com/user-attachments/assets/0c5496fb-f71b-49ce-8778-8e6f6847019d" />
