### PR TITLE
✨Feat: 마이페이지 조회 API 구현

### DIFF
--- a/src/main/java/com/likelion/server/domain/quiz/repository/QuizResultRepository.java
+++ b/src/main/java/com/likelion/server/domain/quiz/repository/QuizResultRepository.java
@@ -6,9 +6,12 @@ import com.likelion.server.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
 public interface QuizResultRepository extends JpaRepository<QuizResult, Long> {
     Optional<QuizResult> findByUserAndQuiz(User user, Quiz quiz);
+
+    List<QuizResult> findAllByUser(User user);
 }

--- a/src/main/java/com/likelion/server/domain/user/service/UserService.java
+++ b/src/main/java/com/likelion/server/domain/user/service/UserService.java
@@ -8,4 +8,6 @@ public interface UserService {
     LoginResponse login(LoginRequest request); // 로그인
 
     HomeResponse getHome(Long userId); // 홈화면
+
+    MyPageResponse getMyPage(Long userId); // 마이페이지
 }

--- a/src/main/java/com/likelion/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/likelion/server/domain/user/service/UserServiceImpl.java
@@ -20,6 +20,8 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.likelion.server.domain.user.web.dto.MyPageResponse;
+import java.util.List;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -147,6 +149,21 @@ public class UserServiceImpl implements UserService {
         return new HomeResponse(groupDtos, qaBoardDtos, scheduleDtos);
     }
 
+    // 마이페이지 조회
+    @Transactional(readOnly = true)
+    @Override
+    public MyPageResponse getMyPage(Long userId) {
+        // 사용자 조회
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        // 사용자가 푼 모든 퀴즈 결과 조회
+        List<QuizResult> results = quizResultRepository.findAllByUser(user);
+
+        // return
+        return new MyPageResponse(user, results);
+    }
+
     // progress 계산 메서드
     private String calculateProgress(User user, Quiz quiz) {
         // 퀴즈에 대한 점수(QuizResult) 조회
@@ -158,7 +175,7 @@ public class UserServiceImpl implements UserService {
             QuizResult result = resultOpt.get();
             int correct = result.getCorrectCount();
             long percent = Math.round((double) correct * 100 / total);
-            return String.format("%d/%d (%d%%)", correct, total, percent); // "19/20 (95%)"
+            return String.format("%d/%d (%d%%)", correct, total, percent);
         } else {
             // 퀴즈를 안 풀었거나, totalQuestions가 0 또는 null인 경우
             return String.format("0/%d (0%%)", total);

--- a/src/main/java/com/likelion/server/domain/user/web/controller/UserController.java
+++ b/src/main/java/com/likelion/server/domain/user/web/controller/UserController.java
@@ -2,6 +2,7 @@ package com.likelion.server.domain.user.web.controller;
 
 import com.likelion.server.domain.user.service.UserService;
 import com.likelion.server.domain.user.web.dto.HomeResponse;
+import com.likelion.server.domain.user.web.dto.MyPageResponse;
 import com.likelion.server.global.response.SuccessResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -14,11 +15,19 @@ public class UserController {
 
     private final UserService userService;
 
-    @GetMapping("/home") //
+    @GetMapping("/home")
     public SuccessResponse<HomeResponse> getHome(
             @AuthenticationPrincipal(expression = "id") Long userId
     ) {
         HomeResponse data = userService.getHome(userId);
+        return SuccessResponse.ok(data);
+    }
+
+    @GetMapping("/mypage")
+    public SuccessResponse<MyPageResponse> getMyPage(
+            @AuthenticationPrincipal(expression = "id") Long userId
+    ) {
+        MyPageResponse data = userService.getMyPage(userId);
         return SuccessResponse.ok(data);
     }
 }

--- a/src/main/java/com/likelion/server/domain/user/web/dto/MyPageResponse.java
+++ b/src/main/java/com/likelion/server/domain/user/web/dto/MyPageResponse.java
@@ -1,0 +1,67 @@
+package com.likelion.server.domain.user.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.likelion.server.domain.quiz.entity.Quiz;
+import com.likelion.server.domain.quiz.entity.QuizResult;
+import com.likelion.server.domain.user.entity.User;
+
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+
+public record MyPageResponse(
+        UserDto user,
+        @JsonProperty("wrong_notes") List<WrongNoteDto> wrongNotes
+) {
+
+    // 사용자 정보
+    public record UserDto(
+            Long id,
+            String nickname
+    ) {
+        public UserDto(User user) {
+            this(
+                    user.getId(),
+                    user.getNickname()
+            );
+        }
+    }
+
+    // 오답노트
+    public record WrongNoteDto(
+            @JsonProperty("quiz_id") Long quizId,
+            @JsonProperty("quiz_title") String quizTitle,
+            @JsonProperty("correct_count") Integer correctCount,
+            @JsonProperty("total_questions") Integer totalQuestions,
+            Long accuracy,
+            @JsonProperty("last_attempt_date") String lastAttemptDate
+    ) {
+        public static WrongNoteDto from(QuizResult result) {
+            Quiz quiz = result.getQuiz();
+            int total = (quiz.getTotalQuestions() != null) ? quiz.getTotalQuestions() : 0;
+            int correct = (result.getCorrectCount() != null) ? result.getCorrectCount() : 0;
+
+            long calculatedAccuracy = 0;
+            if (total > 0) {
+                calculatedAccuracy = Math.round((double) correct * 100 / total);
+            }
+
+            return new WrongNoteDto(
+                    quiz.getId(),
+                    quiz.getTitle(),
+                    correct,
+                    total,
+                    calculatedAccuracy, // "accuracy": 95
+                    result.getCreatedAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME) // "last_attempt_date"
+            );
+        }
+    }
+
+    public MyPageResponse(User user, List<QuizResult> results) {
+        this(
+                new UserDto(user),
+                results.stream()
+                        .map(WrongNoteDto::from)
+                        .toList()
+        );
+    }
+}


### PR DESCRIPTION
## 🔍 관련 이슈
<!--
- close #123
-->
- close #42 

<br>

## ✅ 작업 분류
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
1. 로그인한 사용자의 오답노트 목록을 조회하는 GET /mypage API를 구현했습니다.
2. MyPageResponse DTO를 정의했습니다.
3. QuizResultRepository에 사용자의 모든 퀴즈 결과를 조회하는 findAllByUser 메서드를 추가했습니다.
4. UserServiceImpl에 user 정보와 QuizResult 목록을 조합하는 getMyPage 비즈니스 로직을 구현했습니다.
5. UserController에 GET /mypage 엔드포인트를 추가했습니다.
<br>

## 👥 전달사항
<!--
1. User 도메인 구조를 변경하였습니다.
2. User 도메인 사용자 닉네임 필드를 username -> nickname으로 변경하였습니다.
-->

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
<img width="749" height="543" alt="image" src="https://github.com/user-attachments/assets/d3eacd1e-0e35-4e10-9227-6122ebc461f9" />
