### PR TITLE
✨Feat: 특정 문제 오답 노트 작성 API 구현

### DIFF
--- a/src/main/java/com/likelion/server/domain/quiz/entity/QuizUserAnswer.java
+++ b/src/main/java/com/likelion/server/domain/quiz/entity/QuizUserAnswer.java
@@ -3,6 +3,9 @@ package com.likelion.server.domain.quiz.entity;
 import com.likelion.server.domain.user.entity.User;
 import jakarta.persistence.*;
 import lombok.*;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.LocalDateTime;
 
 @Entity
 @Getter
@@ -28,8 +31,16 @@ public class QuizUserAnswer {
     private User user;
 
     private String userAnswer;
+
     private Boolean isCorrect;
 
     @Column(columnDefinition = "TEXT")
     private String memo;
+
+    @UpdateTimestamp
+    private LocalDateTime reviewUpdatedAt;
+
+    public void updateReview(String memo) {
+        this.memo = memo;
+    }
 }

--- a/src/main/java/com/likelion/server/domain/quiz/exception/QuizErrorCode.java
+++ b/src/main/java/com/likelion/server/domain/quiz/exception/QuizErrorCode.java
@@ -14,7 +14,8 @@ public enum QuizErrorCode implements BaseResponseCode {
     QUIZ_404_NOT_FOUND("QUIZ_404_NOT_FOUND", NOT_FOUND, "해당 퀴즈를 찾을 수 없습니다."),
     QUIZ_RESULT_404_NOT_FOUND("QUIZ_RESULT_404_NOT_FOUND", NOT_FOUND, "해당 퀴즈 결과를 찾을 수 없습니다."),
     QUIZ_INVALID_REQUEST("QUIZ_400_INVALID_REQUEST", BAD_REQUEST, "요청 값이 올바르지 않습니다."),
-    QUIZ_DUPLICATE_ANSWER("QUIZ_400_DUPLICATE_ANSWER", BAD_REQUEST, "이미 응답한 문제입니다.");
+    QUIZ_DUPLICATE_ANSWER("QUIZ_400_DUPLICATE_ANSWER", BAD_REQUEST, "이미 응답한 문제입니다."),
+    QUIZ_USER_ANSWER_NOT_FOUND("QUIZ_ANSWER_404_NOT_FOUND", NOT_FOUND, "해당 문항에 대한 답변 기록을 찾을 수 없습니다.");
 
     private final String code;
     private final int httpStatus;

--- a/src/main/java/com/likelion/server/domain/quiz/exception/QuizUserAnswerNotFoundException.java
+++ b/src/main/java/com/likelion/server/domain/quiz/exception/QuizUserAnswerNotFoundException.java
@@ -1,0 +1,9 @@
+package com.likelion.server.domain.quiz.exception;
+
+import com.likelion.server.global.exception.BaseException;
+
+public class QuizUserAnswerNotFoundException extends BaseException {
+  public QuizUserAnswerNotFoundException() {
+    super(QuizErrorCode.QUIZ_USER_ANSWER_NOT_FOUND);
+  }
+}

--- a/src/main/java/com/likelion/server/domain/quiz/repository/QuizUserAnswerRepository.java
+++ b/src/main/java/com/likelion/server/domain/quiz/repository/QuizUserAnswerRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface QuizUserAnswerRepository extends JpaRepository<QuizUserAnswer, Long> {
@@ -19,4 +20,5 @@ public interface QuizUserAnswerRepository extends JpaRepository<QuizUserAnswer, 
 
     List<QuizUserAnswer> findAllByQuizResultAndIsCorrect(QuizResult quizResult, Boolean isCorrect);
 
+    Optional<QuizUserAnswer> findByQuizResultIdAndQuestionId(Long quizResultId, Long questionId);
 }

--- a/src/main/java/com/likelion/server/domain/user/service/UserService.java
+++ b/src/main/java/com/likelion/server/domain/user/service/UserService.java
@@ -11,5 +11,7 @@ public interface UserService {
 
     MyPageResponse getMyPage(Long userId); // 마이페이지
 
-    WrongNoteDetailResponse getWrongNoteDetail(Long userId, Long quizId); // 오답노트
+    WrongNoteDetailResponse getWrongNoteDetail(Long userId, Long quizId); // 오답노트 조회
+
+    UpdateWrongNoteResponse updateWrongNote(Long userId, Long questionId, UpdateWrongNoteRequest request); // 오답노트 작성/수정
 }

--- a/src/main/java/com/likelion/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/likelion/server/domain/user/service/UserServiceImpl.java
@@ -13,6 +13,7 @@ import com.likelion.server.domain.quiz.repository.QuizOptionRepository;
 import com.likelion.server.domain.quiz.repository.QuizRepository;
 import com.likelion.server.domain.quiz.repository.QuizResultRepository;
 import com.likelion.server.domain.quiz.exception.QuizResultNotFoundException;
+import com.likelion.server.domain.quiz.exception.QuizUserAnswerNotFoundException;
 import com.likelion.server.domain.quiz.repository.QuizUserAnswerRepository;
 import com.likelion.server.domain.user.entity.User;
 import com.likelion.server.domain.user.exception.UserNicknameDuplicatedException;
@@ -172,6 +173,7 @@ public class UserServiceImpl implements UserService {
         return new MyPageResponse(user, results);
     }
 
+    // 오답노트 조회
     @Transactional(readOnly = true)
     @Override
     public WrongNoteDetailResponse getWrongNoteDetail(Long userId, Long quizId) {
@@ -199,6 +201,27 @@ public class UserServiceImpl implements UserService {
 
         // return
         return new WrongNoteDetailResponse(quizResult, wrongQuestionDtos);
+    }
+
+    // 오답노트 작성/수정
+    @Transactional
+    @Override
+    public UpdateWrongNoteResponse updateWrongNote(Long userId, Long questionId, UpdateWrongNoteRequest request) {
+
+        Long quizResultId = request.quizResultId();
+
+        QuizUserAnswer userAnswer = quizUserAnswerRepository.findByQuizResultIdAndQuestionId(quizResultId, questionId)
+                .orElseThrow(QuizUserAnswerNotFoundException::new);
+
+        if (!userAnswer.getUser().getId().equals(userId)) {
+            throw new UserNotFoundException();
+        }
+
+        userAnswer.updateReview(
+                request.memo()
+        );
+
+        return new UpdateWrongNoteResponse(userAnswer);
     }
 
     // progress 계산 메서드

--- a/src/main/java/com/likelion/server/domain/user/web/controller/UserController.java
+++ b/src/main/java/com/likelion/server/domain/user/web/controller/UserController.java
@@ -1,15 +1,12 @@
 package com.likelion.server.domain.user.web.controller;
 
 import com.likelion.server.domain.user.service.UserService;
-import com.likelion.server.domain.user.web.dto.HomeResponse;
-import com.likelion.server.domain.user.web.dto.MyPageResponse;
-import com.likelion.server.domain.user.web.dto.WrongNoteDetailResponse;
+import com.likelion.server.domain.user.web.dto.*;
 import com.likelion.server.global.response.SuccessResponse;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -39,6 +36,16 @@ public class UserController {
             @PathVariable("quiz_id") Long quizId
     ) {
         WrongNoteDetailResponse data = userService.getWrongNoteDetail(userId, quizId);
+        return SuccessResponse.ok(data);
+    }
+
+    @PatchMapping("/mypage/wrong-note/{question_id}/review") //
+    public SuccessResponse<UpdateWrongNoteResponse> updateWrongNote(
+            @AuthenticationPrincipal(expression = "id") Long userId,
+            @PathVariable("question_id") Long questionId,
+            @Valid @RequestBody UpdateWrongNoteRequest request
+    ) {
+        UpdateWrongNoteResponse data = userService.updateWrongNote(userId, questionId, request);
         return SuccessResponse.ok(data);
     }
 }

--- a/src/main/java/com/likelion/server/domain/user/web/dto/UpdateWrongNoteRequest.java
+++ b/src/main/java/com/likelion/server/domain/user/web/dto/UpdateWrongNoteRequest.java
@@ -1,0 +1,12 @@
+package com.likelion.server.domain.user.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotNull;
+
+public record UpdateWrongNoteRequest(
+        @NotNull
+        @JsonProperty("quiz_result_id")
+        Long quizResultId,
+        String memo
+) {
+}

--- a/src/main/java/com/likelion/server/domain/user/web/dto/UpdateWrongNoteResponse.java
+++ b/src/main/java/com/likelion/server/domain/user/web/dto/UpdateWrongNoteResponse.java
@@ -1,0 +1,35 @@
+package com.likelion.server.domain.user.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.likelion.server.domain.quiz.entity.QuizUserAnswer;
+import java.time.format.DateTimeFormatter;
+
+public record UpdateWrongNoteResponse(
+        @JsonProperty("question_id")
+        Long questionId,
+
+        ReviewDto review
+) {
+    public record ReviewDto(
+            String memo,
+
+            @JsonProperty("review_updated_at")
+            String reviewUpdatedAt
+    ) {
+        public ReviewDto(QuizUserAnswer answer) {
+            this(
+                    answer.getMemo(),
+                    (answer.getReviewUpdatedAt() != null)
+                            ? answer.getReviewUpdatedAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
+                            : null
+            );
+        }
+    }
+
+    public UpdateWrongNoteResponse(QuizUserAnswer answer) {
+        this(
+                answer.getQuestion().getId(),
+                new ReviewDto(answer)
+        );
+    }
+}

--- a/src/main/java/com/likelion/server/global/config/WebConfig.java
+++ b/src/main/java/com/likelion/server/global/config/WebConfig.java
@@ -10,7 +10,7 @@ public class WebConfig implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowedOrigins("http://localhost:5173", "https://likelion13-changuphalgak.netlify.app")
-                .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
                 .allowCredentials(true);
     }
 }


### PR DESCRIPTION
## 🔍 관련 이슈
<!--
- close #123
-->
- close #46 

<br>

## ✅ 작업 분류
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경
- [x] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
1. QuizUserAnswer 엔티티에 reviewUpdatedAt 필드를 반영했습니다.
2. API 요청/응답을 처리할 UpdateWrongNoteRequest, UpdateWrongNoteResponse DTO를 정의했습니다.
3. QuizUserAnswerRepository에 findByQuizResultIdAndQuestionId 메서드를 추가하여 특정 답변을 조회할 수 있도록 했습니다.
4. UserServiceImpl에 updateWrongNote 비즈니스 로직을 구현했습니다.
5. UserController에 해당 PATCH 엔드포인트를 추가했습니다.
6. WebConfig에 PATCH 메서드를 사용할 수 있도록 추가했습니다.

<br>

## 👥 전달사항
마찬가지로 테스트는 추후 진행하겠습니다.

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
<img width="757" height="521" alt="image" src="https://github.com/user-attachments/assets/785eb82c-68a2-48ac-a147-8ed59ba6c264" />
