### PR TITLE
✨Feat: 기본 정보 변경 API 구현

### DIFF
--- a/src/main/java/com/likelion/server/domain/user/entity/User.java
+++ b/src/main/java/com/likelion/server/domain/user/entity/User.java
@@ -36,6 +36,14 @@ public class User extends BaseEntity {
         this.password = password;
     }
 
+    public void updateNickname(String newNickname) {
+        this.nickname = newNickname;
+    }
+
+    public void updatePassword(String newEncodedPassword) {
+        this.password = newEncodedPassword;
+    }
+
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }

--- a/src/main/java/com/likelion/server/domain/user/service/UserService.java
+++ b/src/main/java/com/likelion/server/domain/user/service/UserService.java
@@ -14,4 +14,6 @@ public interface UserService {
     WrongNoteDetailResponse getWrongNoteDetail(Long userId, Long quizId); // 오답노트 조회
 
     UpdateWrongNoteResponse updateWrongNote(Long userId, Long questionId, UpdateWrongNoteRequest request); // 오답노트 작성/수정
+
+    UserResponse updateProfile(Long userId, UpdateProfileRequest request); // 개인정보 변경
 }

--- a/src/main/java/com/likelion/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/likelion/server/domain/user/service/UserServiceImpl.java
@@ -27,6 +27,8 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import com.likelion.server.domain.user.web.dto.MyPageResponse;
+import org.springframework.util.StringUtils;
+
 import java.util.List;
 
 import java.util.*;
@@ -222,6 +224,36 @@ public class UserServiceImpl implements UserService {
         );
 
         return new UpdateWrongNoteResponse(userAnswer);
+    }
+
+    // 개인정보 변경
+    @Transactional
+    @Override
+    public UserResponse updateProfile(Long userId, UpdateProfileRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+
+        // 닉네임 변경
+        String newNickname = request.nickname();
+        if (StringUtils.hasText(newNickname) && !newNickname.equals(user.getNickname())) {
+            // 새 닉네임이 중복인지 확인
+            if (userRepository.existsByNickname(newNickname)) {
+                throw new UserNicknameDuplicatedException();
+            }
+            user.updateNickname(newNickname);
+        }
+
+        // 비밀번호 변경
+        String newPassword = request.password();
+        if (StringUtils.hasText(newPassword)) {
+            // 비밀번호 확인란과 일치하는지 확인
+            if (!newPassword.equals(request.passwordCheck())) {
+                throw new UserPasswordMismatchException();
+            }
+            user.updatePassword(passwordEncoder.encode(newPassword));
+        }
+
+        return new UserResponse(user.getId(), user.getNickname());
     }
 
     // progress 계산 메서드

--- a/src/main/java/com/likelion/server/domain/user/web/controller/UserController.java
+++ b/src/main/java/com/likelion/server/domain/user/web/controller/UserController.java
@@ -48,4 +48,13 @@ public class UserController {
         UpdateWrongNoteResponse data = userService.updateWrongNote(userId, questionId, request);
         return SuccessResponse.ok(data);
     }
+
+    @PatchMapping("/mypage/profile")
+    public SuccessResponse<UserResponse> updateProfile(
+            @AuthenticationPrincipal(expression = "id") Long userId,
+            @Valid @RequestBody UpdateProfileRequest request
+    ) {
+        UserResponse data = userService.updateProfile(userId, request);
+        return SuccessResponse.ok(data);
+    }
 }

--- a/src/main/java/com/likelion/server/domain/user/web/dto/UpdateProfileRequest.java
+++ b/src/main/java/com/likelion/server/domain/user/web/dto/UpdateProfileRequest.java
@@ -1,0 +1,18 @@
+package com.likelion.server.domain.user.web.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Size;
+import jakarta.validation.constraints.Pattern;
+
+public record UpdateProfileRequest(
+        @Size(min = 2, max = 10, message = "닉네임은 2~10자 이내로 입력해주세요.")
+        String nickname,
+
+        @Pattern(regexp = "^(?=.*[a-zA-Z])(?=.*\\d)[a-zA-Z\\d]{4,15}$",
+                message = "비밀번호는 4자 이상 15자 이하이며, 영문자와 숫자를 최소 1개 이상 포함해야 합니다.")
+        String password,
+
+        @JsonProperty("passwordCheck")
+        String passwordCheck
+) {
+}


### PR DESCRIPTION
## 🔍 관련 이슈
<!--
- close #123
-->
- close #50 

<br>

## ✅ 작업 분류
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
1. 마이페이지의 개인정보 변경(PATCH /mypage/profile) API를 구현했습니다.
2. UpdateProfileRequest DTO를 정의하여, 닉네임(@Size) 및 비밀번호(@Pattern) 유효성 검사를 추가했습니다.
3. User 엔티티에 updateNickname, updatePassword 메서드를 추가하여 데이터가 수정되도록 했습니다.
4. UserServiceImpl에 updateProfile 로직을 구현하여, 닉네임만, 비밀번호만, 또는 둘 다 동시에 변경할 수 있도록 했습니다.
5. UserController에 해당 API 엔드포인트를 추가했습니다.


<br>

## 👥 전달사항
<!--
1. User 도메인 구조를 변경하였습니다.
2. User 도메인 사용자 닉네임 필드를 username -> nickname으로 변경하였습니다.
-->

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
<img width="759" height="580" alt="image" src="https://github.com/user-attachments/assets/1b8c5554-9fd5-4f1e-8740-43317fd17d67" />
