### PR TITLE
✨Feat: 그룹 퇴장 API 구현

### DIFF
--- a/src/main/java/com/likelion/server/domain/group/exception/GroupErrorCode.java
+++ b/src/main/java/com/likelion/server/domain/group/exception/GroupErrorCode.java
@@ -4,14 +4,14 @@ import com.likelion.server.global.response.code.BaseResponseCode;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 
-import static com.likelion.server.global.constant.StaticValue.CONFLICT;
-import static com.likelion.server.global.constant.StaticValue.NOT_FOUND;
+import static com.likelion.server.global.constant.StaticValue.*;
 
 @Getter
 @AllArgsConstructor
 public enum GroupErrorCode implements BaseResponseCode {
     GROUP_404_NOT_FOUND_BY_CODE("GROUP_404_NOT_FOUND_BY_CODE", NOT_FOUND, "존재하지 않는 그룹 코드입니다."),
-    GROUP_409_ALREADY_MEMBER("GROUP_409_ALREADY_MEMBER", CONFLICT, "이미 가입된 그룹입니다.");
+    GROUP_409_ALREADY_MEMBER("GROUP_409_ALREADY_MEMBER", CONFLICT, "이미 가입된 그룹입니다."),
+    GROUP_403_PERMISSION_DENIED("GROUP_403_PERMISSION_DENIED", FORBIDDEN, "이 작업을 수행할 권한이 없습니다.");
 
     private final String code;
     private final int httpStatus;

--- a/src/main/java/com/likelion/server/domain/group/exception/GroupPermissionDeniedException.java
+++ b/src/main/java/com/likelion/server/domain/group/exception/GroupPermissionDeniedException.java
@@ -1,0 +1,9 @@
+package com.likelion.server.domain.group.exception;
+
+import com.likelion.server.global.exception.BaseException;
+
+public class GroupPermissionDeniedException extends BaseException {
+  public GroupPermissionDeniedException() {
+    super(GroupErrorCode.GROUP_403_PERMISSION_DENIED);
+  }
+}

--- a/src/main/java/com/likelion/server/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/likelion/server/domain/group/repository/GroupMemberRepository.java
@@ -6,6 +6,7 @@ import com.likelion.server.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface GroupMemberRepository extends JpaRepository<Member, Long> {
     boolean existsByGroupIdAndUserId(Long groupId, Long userId);
@@ -13,4 +14,6 @@ public interface GroupMemberRepository extends JpaRepository<Member, Long> {
     List<Member> findAllByUser(User user);
 
     Integer countByGroup(Group group);
+
+    Optional<Member> findByUserAndGroup(User user, Group group);
 }

--- a/src/main/java/com/likelion/server/domain/group/service/GroupService.java
+++ b/src/main/java/com/likelion/server/domain/group/service/GroupService.java
@@ -7,4 +7,5 @@ import com.likelion.server.domain.group.web.dto.GroupJoinResponse;
 public interface GroupService {
     CreateGroupResponse create(Long userId, CreateGroupRequest req);
     GroupJoinResponse joinByCode(Long userId, String groupCode);
+    void leaveGroup(Long userId, Long groupId);
 }

--- a/src/main/java/com/likelion/server/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/com/likelion/server/domain/group/service/GroupServiceImpl.java
@@ -4,21 +4,33 @@ import com.likelion.server.domain.group.entity.Group;
 import com.likelion.server.domain.group.entity.Member;
 import com.likelion.server.domain.group.entity.enums.Role;
 import com.likelion.server.domain.group.exception.AlreadyGroupMemberException;
-import com.likelion.server.domain.group.exception.GroupErrorCode;
 import com.likelion.server.domain.group.exception.GroupNotFoundException;
+import com.likelion.server.domain.group.exception.GroupPermissionDeniedException;
 import com.likelion.server.domain.group.repository.GroupMemberRepository;
 import com.likelion.server.domain.group.repository.StudyGroupRepository;
 import com.likelion.server.domain.group.web.dto.CreateGroupRequest;
 import com.likelion.server.domain.group.web.dto.CreateGroupResponse;
 import com.likelion.server.domain.group.web.dto.GroupJoinResponse;
+import com.likelion.server.domain.pdf.repository.PdfRepository;
+import com.likelion.server.domain.qa.entity.QaBoard;
+import com.likelion.server.domain.qa.entity.QaPost;
+import com.likelion.server.domain.qa.repository.QaBoardRepository;
+import com.likelion.server.domain.qa.repository.QaCommentRepository;
+import com.likelion.server.domain.qa.repository.QaPostRepository;
+import com.likelion.server.domain.quiz.entity.Quiz;
+import com.likelion.server.domain.quiz.entity.QuizResult;
+import com.likelion.server.domain.quiz.repository.*;
 import com.likelion.server.domain.user.entity.User;
+import com.likelion.server.domain.user.repository.UserRepository;
 import jakarta.persistence.EntityManager;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.security.SecureRandom;
 import java.time.LocalDate;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -28,6 +40,17 @@ public class GroupServiceImpl implements GroupService {
     private final StudyGroupRepository studyGroupRepository;
     private final GroupMemberRepository groupMemberRepository;
     private final EntityManager em;
+
+    private final UserRepository userRepository;
+    private final PdfRepository pdfRepository;
+    private final QuizRepository quizRepository;
+    private final QuizQuestionRepository quizQuestionRepository;
+    private final QuizOptionRepository quizOptionRepository;
+    private final QuizResultRepository quizResultRepository;
+    private final QuizUserAnswerRepository quizUserAnswerRepository;
+    private final QaBoardRepository qaBoardRepository;
+    private final QaPostRepository qaPostRepository;
+    private final QaCommentRepository qaCommentRepository;
 
     private static final char[] CODE_CHARS = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789".toCharArray();
     private static final SecureRandom RND = new SecureRandom();
@@ -95,6 +118,27 @@ public class GroupServiceImpl implements GroupService {
         return new GroupJoinResponse(group.getId());
     }
 
+    // 퇴장하기(MEMBER)
+    @Override
+    public void leaveGroup(Long userId, Long groupId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+        Group group = studyGroupRepository.findById(groupId)
+                .orElseThrow(GroupNotFoundException::new);
+
+        Member member = groupMemberRepository.findByUserAndGroup(user, group)
+                .orElseThrow(() -> new GroupNotFoundException()); // 이 그룹 멤버가 아님
+
+        // 방장은 퇴장 불가
+        if (member.getRole() == Role.LEADER) {
+            throw new GroupPermissionDeniedException();
+        }
+
+        deletePersonalQuizActivity(user, group);
+
+        groupMemberRepository.delete(member);
+    }
+
     private String generateUniqueCode(int length) {
         String code;
         int attempts = 0;
@@ -111,5 +155,23 @@ public class GroupServiceImpl implements GroupService {
         StringBuilder sb = new StringBuilder(length);
         for (int i = 0; i < length; i++) sb.append(CODE_CHARS[RND.nextInt(CODE_CHARS.length)]);
         return sb.toString();
+    }
+
+    private void deletePersonalQuizActivity(User user, Group group) {
+        // 이 그룹의 모든 퀴즈 조회
+        List<Quiz> quizzesInGroup = quizRepository.findAllByGroup(group);
+        if (quizzesInGroup.isEmpty()) return; // 퀴즈가 없으면 활동 기록도 없음
+
+        // 이 퀴즈들에 대한 나의 모든 응시 결과(QuizResult) 조회
+        List<QuizResult> myResults = quizResultRepository.findAllByUserAndQuizIn(user, quizzesInGroup);
+        if (!myResults.isEmpty()) {
+            // 나의 모든 답안(QuizUserAnswer) 삭제
+            quizUserAnswerRepository.deleteAllByQuizResultIn(myResults);
+            // 나의 모든 퀴즈 결과(QuizResult) 삭제
+            quizResultRepository.deleteAll(myResults);
+        }
+
+        // 나의 랭킹 삭제
+        // groupRankingRepository.deleteByUserAndGroup(user, group);
     }
 }

--- a/src/main/java/com/likelion/server/domain/group/web/controller/GroupController.java
+++ b/src/main/java/com/likelion/server/domain/group/web/controller/GroupController.java
@@ -9,10 +9,7 @@ import com.likelion.server.global.response.SuccessResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -39,5 +36,15 @@ public class GroupController {
     ) {
         GroupJoinResponse data = groupService.joinByCode(userId, groupJoinRequest.groupCode());
         return SuccessResponse.ok(data);
+    }
+
+    // 그룹 퇴장(MEMBER)
+    @DeleteMapping("/group/{group_id}/leave")
+    public SuccessResponse<Void> leaveGroup(
+            @AuthenticationPrincipal(expression = "id") Long userId,
+            @PathVariable("group_id") Long groupId
+    ) {
+        groupService.leaveGroup(userId, groupId);
+        return SuccessResponse.ok(null);
     }
 }

--- a/src/main/java/com/likelion/server/domain/quiz/repository/QuizResultRepository.java
+++ b/src/main/java/com/likelion/server/domain/quiz/repository/QuizResultRepository.java
@@ -16,4 +16,6 @@ public interface QuizResultRepository extends JpaRepository<QuizResult, Long> {
     List<QuizResult> findAllByUser(User user);
 
     Optional<QuizResult> findByUserAndQuizId(User user, Long quizId);
+
+    List<QuizResult> findAllByUserAndQuizIn(User user, List<Quiz> quizzes);
 }

--- a/src/main/java/com/likelion/server/domain/quiz/repository/QuizUserAnswerRepository.java
+++ b/src/main/java/com/likelion/server/domain/quiz/repository/QuizUserAnswerRepository.java
@@ -21,4 +21,6 @@ public interface QuizUserAnswerRepository extends JpaRepository<QuizUserAnswer, 
     List<QuizUserAnswer> findAllByQuizResultAndIsCorrect(QuizResult quizResult, Boolean isCorrect);
 
     Optional<QuizUserAnswer> findByQuizResultIdAndQuestionId(Long quizResultId, Long questionId);
+
+    void deleteAllByQuizResultIn(List<QuizResult> quizResults);
 }

--- a/src/main/java/com/likelion/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/likelion/server/domain/user/service/UserServiceImpl.java
@@ -2,6 +2,7 @@ package com.likelion.server.domain.user.service;
 
 import com.likelion.server.domain.group.entity.Group;
 import com.likelion.server.domain.group.entity.Member;
+import com.likelion.server.domain.group.entity.enums.Role;
 import com.likelion.server.domain.group.repository.GroupMemberRepository;
 import com.likelion.server.domain.qa.entity.QaBoard;
 import com.likelion.server.domain.qa.repository.QaBoardRepository;
@@ -112,30 +113,30 @@ public class UserServiceImpl implements UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
 
-        // 사용자가 속한 모든 그룹 조회
-        List<Group> userGroups = memberRepository.findAllByUser(user)
-                .stream()
-                .map(Member::getGroup)
+        List<Member> memberships = memberRepository.findAllByUser(user);
+
+        // 2. [groups] DTO 목록 생성 (Quiz Room)
+        List<HomeResponse.GroupDto> groupDtos = memberships.stream()
+                .map(member -> {
+                    Group group = member.getGroup();
+                    Role role = member.getRole();
+                    Integer memberCount = memberRepository.countByGroup(group);
+
+                    return new HomeResponse.GroupDto(group, memberCount, role);
+                })
                 .toList();
 
-        // [groups] DTO 목록 생성 (Quiz Room)
-        List<HomeResponse.GroupDto> groupDtos = userGroups.stream()
-                .map(group -> {
-                    Integer memberCount = memberRepository.countByGroup(group);
-                    return new HomeResponse.GroupDto(group, memberCount);
-                })
-                .collect(Collectors.toList());
-
-        // [exam_schedule] DTO 목록 생성 (Exam Date)
-        List<HomeResponse.ExamScheduleDto> scheduleDtos = userGroups.stream()
+        // 3. [exam_schedule] DTO 목록 생성 (Exam Date)
+        List<HomeResponse.ExamScheduleDto> scheduleDtos = memberships.stream()
+                .map(Member::getGroup)
                 .filter(group -> group.getExamDate() != null && !group.getExamDate().isEmpty())
                 .map(HomeResponse.ExamScheduleDto::new)
-                .collect(Collectors.toList());
+                .toList();
 
-        // [qa_board] DTO 목록 생성 (Q&A 게시판)
+        // 4. [qa_board] DTO 목록 생성 (Q&A 게시판)
         List<HomeResponse.QaBoardDto> qaBoardDtos = new ArrayList<>();
 
-        // 사용자가 속한 그룹의 모든 퀴즈를 조회
+        List<Group> userGroups = memberships.stream().map(Member::getGroup).toList();
         List<Quiz> allQuizzes = userGroups.stream()
                 .flatMap(group -> quizRepository.findAllByGroup(group).stream())
                 .toList();

--- a/src/main/java/com/likelion/server/domain/user/web/dto/HomeResponse.java
+++ b/src/main/java/com/likelion/server/domain/user/web/dto/HomeResponse.java
@@ -2,6 +2,7 @@ package com.likelion.server.domain.user.web.dto;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.likelion.server.domain.group.entity.Group;
+import com.likelion.server.domain.group.entity.enums.Role;
 import com.likelion.server.domain.qa.entity.QaBoard;
 
 import java.util.List;
@@ -16,14 +17,16 @@ public record HomeResponse(
             Long id,
             String name,
             @JsonProperty("exam_date") String examDate,
-            @JsonProperty("member_count") Integer memberCount
+            @JsonProperty("member_count") Integer memberCount,
+            @JsonProperty("role") String role
     ) {
-        public GroupDto(Group group, Integer memberCount) {
+        public GroupDto(Group group, Integer memberCount, Role role) {
             this(
                     group.getId(),
                     group.getName(),
                     group.getExamDate(),
-                    memberCount
+                    memberCount,
+                    role.toString()
             );
         }
     }


### PR DESCRIPTION
## 🔍 관련 이슈
<!--
- close #123
-->
- close #48 

<br>

## ✅ 작업 분류
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
1. MEMBER용 그룹 퇴장 API를 구현했습니다.
2. GroupServiceImpl에 leaveGroup 메서드를 구현했습니다.
3. GroupController에 해당 엔드포인트를 추가하고 관련 예외 처리를 완료했습니다.

- 삭제 대상
  - member (본인 가입 정보)
  - quiz_result / quiz_user_answer (본인의 퀴즈/오답노트 기록)
  - group_ranking (본인 랭킹)
<br>

## 👥 전달사항
- MEMBER 역할의 사용자만 이 API를 호출하여 그룹에서 나갈 수 있습니다.
- LEADER 역할의 사용자가 이 API를 호출하면 GroupPermissionDeniedException (403 Forbidden)이 발생합니다.
- QA 게시판(게시글/댓글) 기록은 보존되고, 퀴즈 관련 기록만 삭제됩니다.

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
### 멤버 퇴장
<img width="748" height="460" alt="image" src="https://github.com/user-attachments/assets/e2d887fd-bced-48c5-b616-42bfb775075e" />

### 방장 권한으로 퇴장 시도할 시
<img width="765" height="431" alt="image" src="https://github.com/user-attachments/assets/42459a97-0e6e-4a43-be28-05c0e16c3de7" />
