### PR TITLE
✨Feat: 그룹 삭제 API 구현

### DIFF
--- a/src/main/java/com/likelion/server/domain/group/repository/GroupMemberRepository.java
+++ b/src/main/java/com/likelion/server/domain/group/repository/GroupMemberRepository.java
@@ -16,4 +16,6 @@ public interface GroupMemberRepository extends JpaRepository<Member, Long> {
     Integer countByGroup(Group group);
 
     Optional<Member> findByUserAndGroup(User user, Group group);
+
+    List<Member> findAllByGroup(Group group);
 }

--- a/src/main/java/com/likelion/server/domain/group/service/GroupService.java
+++ b/src/main/java/com/likelion/server/domain/group/service/GroupService.java
@@ -8,4 +8,5 @@ public interface GroupService {
     CreateGroupResponse create(Long userId, CreateGroupRequest req);
     GroupJoinResponse joinByCode(Long userId, String groupCode);
     void leaveGroup(Long userId, Long groupId);
+    void deleteGroup(Long userId, Long groupId);
 }

--- a/src/main/java/com/likelion/server/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/com/likelion/server/domain/group/service/GroupServiceImpl.java
@@ -11,7 +11,9 @@ import com.likelion.server.domain.group.repository.StudyGroupRepository;
 import com.likelion.server.domain.group.web.dto.CreateGroupRequest;
 import com.likelion.server.domain.group.web.dto.CreateGroupResponse;
 import com.likelion.server.domain.group.web.dto.GroupJoinResponse;
+import com.likelion.server.domain.pdf.entity.Pdf;
 import com.likelion.server.domain.pdf.repository.PdfRepository;
+import com.likelion.server.domain.pdf.service.PdfService;
 import com.likelion.server.domain.qa.entity.QaBoard;
 import com.likelion.server.domain.qa.entity.QaPost;
 import com.likelion.server.domain.qa.repository.QaBoardRepository;
@@ -43,6 +45,7 @@ public class GroupServiceImpl implements GroupService {
 
     private final UserRepository userRepository;
     private final PdfRepository pdfRepository;
+    private final PdfService pdfService;
     private final QuizRepository quizRepository;
     private final QuizQuestionRepository quizQuestionRepository;
     private final QuizOptionRepository quizOptionRepository;
@@ -118,7 +121,7 @@ public class GroupServiceImpl implements GroupService {
         return new GroupJoinResponse(group.getId());
     }
 
-    // 퇴장하기(MEMBER)
+    // 그룹 퇴장(MEMBER)
     @Override
     public void leaveGroup(Long userId, Long groupId) {
         User user = userRepository.findById(userId)
@@ -139,6 +142,27 @@ public class GroupServiceImpl implements GroupService {
         groupMemberRepository.delete(member);
     }
 
+    // 그룹삭제(LEADER)
+    @Override
+    public void deleteGroup(Long userId, Long groupId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+        Group group = studyGroupRepository.findById(groupId)
+                .orElseThrow(GroupNotFoundException::new);
+
+        Member member = groupMemberRepository.findByUserAndGroup(user, group)
+                .orElseThrow(() -> new GroupNotFoundException());
+
+        // 멤버는 삭제 불가
+        if (member.getRole() == Role.MEMBER) {
+            throw new GroupPermissionDeniedException();
+        }
+
+        deleteAllGroupData(group);
+
+        studyGroupRepository.delete(group);
+    }
+
     private String generateUniqueCode(int length) {
         String code;
         int attempts = 0;
@@ -157,6 +181,7 @@ public class GroupServiceImpl implements GroupService {
         return sb.toString();
     }
 
+    // 그룹 퇴장 - 특정 유저의 개인 활동 기록만 삭제
     private void deletePersonalQuizActivity(User user, Group group) {
         // 이 그룹의 모든 퀴즈 조회
         List<Quiz> quizzesInGroup = quizRepository.findAllByGroup(group);
@@ -173,5 +198,58 @@ public class GroupServiceImpl implements GroupService {
 
         // 나의 랭킹 삭제
         // groupRankingRepository.deleteByUserAndGroup(user, group);
+    }
+
+    // 그룹 삭제 - 그룹의 모든 데이터를 삭제
+    private void deleteAllGroupData(Group group) {
+        // 그룹의 모든 퀴즈/게시판 조회
+        List<Quiz> quizzesInGroup = quizRepository.findAllByGroup(group);
+        List<QaBoard> boardsInGroup = qaBoardRepository.findAllByGroup(group);
+
+        if (!quizzesInGroup.isEmpty()) {
+            // 모든 퀴즈 결과(QuizResult) 조회
+            List<QuizResult> allResults = quizResultRepository.findAllByQuizIn(quizzesInGroup);
+            if (!allResults.isEmpty()) {
+                // 모든 답안(QuizUserAnswer) 삭제
+                quizUserAnswerRepository.deleteAllByQuizResultIn(allResults);
+                // 모든 퀴즈 결과(QuizResult) 삭제
+                quizResultRepository.deleteAll(allResults);
+            }
+            // 모든 퀴즈 문항/보기 삭제
+            quizzesInGroup.forEach(quiz -> {
+                quizQuestionRepository.findAllByQuiz(quiz).forEach(question -> {
+                    quizOptionRepository.deleteAllByQuestion(question);
+                });
+                quizQuestionRepository.deleteAllByQuiz(quiz);
+            });
+            // 모든 퀴즈(Quiz) 삭제
+            quizRepository.deleteAll(quizzesInGroup);
+        }
+
+        if (!boardsInGroup.isEmpty()) {
+            // 모든 게시글(QaPost) 조회
+            List<QaPost> allPosts = qaPostRepository.findAllByBoardIn(boardsInGroup);
+            if (!allPosts.isEmpty()) {
+                // 모든 댓글(QaComment) 삭제
+                qaCommentRepository.deleteAllByPostIn(allPosts);
+                // 모든 게시글(QaPost) 삭제
+                qaPostRepository.deleteAll(allPosts);
+            }
+            // 모든 QA 게시판(QaBoard) 삭제
+            qaBoardRepository.deleteAll(boardsInGroup);
+        }
+
+        // 그룹의 모든 PDF 엔티티를 조회
+        List<Pdf> pdfsInGroup = pdfRepository.findAllByGroupId(group.getId());
+        // S3와 DB에서 모두 삭제
+        for (Pdf pdf : pdfsInGroup) {
+            pdfService.delete(pdf.getId());
+        }
+
+        // 모든 랭킹(GroupRanking) 삭제
+        // groupRankingRepository.deleteAllByGroup(group);
+
+        // 모든 멤버(Member) 삭제
+        groupMemberRepository.deleteAll(groupMemberRepository.findAllByGroup(group));
     }
 }

--- a/src/main/java/com/likelion/server/domain/group/web/controller/GroupController.java
+++ b/src/main/java/com/likelion/server/domain/group/web/controller/GroupController.java
@@ -47,4 +47,14 @@ public class GroupController {
         groupService.leaveGroup(userId, groupId);
         return SuccessResponse.ok(null);
     }
+
+    // 그룹 삭제(LEADER)
+    @DeleteMapping("/group/{group_id}")
+    public SuccessResponse<Void> deleteGroup(
+            @AuthenticationPrincipal(expression = "id") Long userId,
+            @PathVariable("group_id") Long groupId
+    ) {
+        groupService.deleteGroup(userId, groupId);
+        return SuccessResponse.ok(null);
+    }
 }

--- a/src/main/java/com/likelion/server/domain/pdf/repository/PdfRepository.java
+++ b/src/main/java/com/likelion/server/domain/pdf/repository/PdfRepository.java
@@ -1,5 +1,6 @@
 package com.likelion.server.domain.pdf.repository;
 
+import com.likelion.server.domain.group.entity.Group;
 import com.likelion.server.domain.pdf.entity.Pdf;
 import org.springframework.data.jpa.repository.JpaRepository;
 

--- a/src/main/java/com/likelion/server/domain/pdf/service/PdfService.java
+++ b/src/main/java/com/likelion/server/domain/pdf/service/PdfService.java
@@ -9,7 +9,7 @@ public interface PdfService {
 
     PdfUploadResponse upload(Long userId, Long groupId, MultipartFile file);
 
-    PdfDeleteResponse delete(Long pdfId, Long userId);
+    PdfDeleteResponse delete(Long pdfId);
 
     PdfGroupListResponse getPdfListByGroup(Long groupId);
 }

--- a/src/main/java/com/likelion/server/domain/pdf/service/PdfServiceImpl.java
+++ b/src/main/java/com/likelion/server/domain/pdf/service/PdfServiceImpl.java
@@ -101,14 +101,9 @@ public class PdfServiceImpl implements PdfService {
 
     // PDF 삭제
     @Override
-    public PdfDeleteResponse delete(Long pdfId, Long userId) {
+    public PdfDeleteResponse delete(Long pdfId) {
         Pdf pdf = pdfRepository.findById(pdfId)
                 .orElseThrow(() -> new IllegalArgumentException("해당 PDF를 찾을 수 없습니다."));
-
-        // 업로더 본인 확인
-        if (!pdf.getUploader().getId().equals(userId)) {
-            throw new SecurityException("본인이 업로드한 파일만 삭제할 수 있습니다.");
-        }
 
         // S3 키 추출 (버킷 내 경로)
         String key = extractS3Key(pdf.getS3Url());
@@ -124,7 +119,7 @@ public class PdfServiceImpl implements PdfService {
         // DB에서 삭제
         pdfRepository.delete(pdf);
 
-        User uploader = em.find(User.class, userId);
+        User uploader = pdf.getUploader();
 
         return PdfDeleteResponse.builder()
                 .id(pdf.getId())

--- a/src/main/java/com/likelion/server/domain/pdf/web/controller/PdfController.java
+++ b/src/main/java/com/likelion/server/domain/pdf/web/controller/PdfController.java
@@ -32,10 +32,9 @@ public class PdfController {
     // PDF 삭제
     @DeleteMapping("/{pdf_id}")
     public SuccessResponse<PdfDeleteResponse> deletePdf(
-            @AuthenticationPrincipal(expression = "id") Long userId,
             @PathVariable("pdf_id") Long pdfId
     ) {
-        PdfDeleteResponse data = pdfServiceImpl.delete(pdfId, userId);
+        PdfDeleteResponse data = pdfServiceImpl.delete(pdfId);
         return SuccessResponse.ok(data);
     }
 

--- a/src/main/java/com/likelion/server/domain/qa/repository/QaBoardRepository.java
+++ b/src/main/java/com/likelion/server/domain/qa/repository/QaBoardRepository.java
@@ -1,9 +1,11 @@
 package com.likelion.server.domain.qa.repository;
 
+import com.likelion.server.domain.group.entity.Group;
 import com.likelion.server.domain.qa.entity.QaBoard;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 @Repository
@@ -11,4 +13,6 @@ public interface QaBoardRepository extends JpaRepository<QaBoard, Long> {
 
     // 특정 퀴즈에 연결된 QA 게시판 조회
     Optional<QaBoard> findByQuizId(Long quizId);
+
+    List<QaBoard> findAllByGroup(Group group);
 }

--- a/src/main/java/com/likelion/server/domain/qa/repository/QaCommentRepository.java
+++ b/src/main/java/com/likelion/server/domain/qa/repository/QaCommentRepository.java
@@ -12,4 +12,6 @@ public interface QaCommentRepository extends JpaRepository<QaComment, Long> {
 
     // 특정 게시글에 속한 모든 댓글 목록 조회
     List<QaComment> findAllByPost(QaPost post);
+
+    void deleteAllByPostIn(List<QaPost> allPosts);
 }

--- a/src/main/java/com/likelion/server/domain/qa/repository/QaPostRepository.java
+++ b/src/main/java/com/likelion/server/domain/qa/repository/QaPostRepository.java
@@ -9,4 +9,6 @@ import java.util.List;
 public interface QaPostRepository extends JpaRepository<QaPost, Long> {
     // 특정 게시판에 속한 게시글 목록 조회
     List<QaPost> findAllByBoard(QaBoard board);
+
+    List<QaPost> findAllByBoardIn(List<QaBoard> boardsInGroup);
 }

--- a/src/main/java/com/likelion/server/domain/quiz/repository/QuizOptionRepository.java
+++ b/src/main/java/com/likelion/server/domain/quiz/repository/QuizOptionRepository.java
@@ -11,4 +11,6 @@ import java.util.List;
 public interface QuizOptionRepository extends JpaRepository<QuizOption, Long> {
     // 질문 ID 기준 보기 조회
     List<QuizOption> findAllByQuestion(QuizQuestion question);
+
+    void deleteAllByQuestion(QuizQuestion question);
 }

--- a/src/main/java/com/likelion/server/domain/quiz/repository/QuizQuestionRepository.java
+++ b/src/main/java/com/likelion/server/domain/quiz/repository/QuizQuestionRepository.java
@@ -1,5 +1,6 @@
 package com.likelion.server.domain.quiz.repository;
 
+import com.likelion.server.domain.quiz.entity.Quiz;
 import com.likelion.server.domain.quiz.entity.QuizQuestion;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -10,4 +11,8 @@ public interface QuizQuestionRepository extends JpaRepository<QuizQuestion, Long
 
     // ✅ 퀴즈 ID 기준으로 문제 조회
     List<QuizQuestion> findAllByQuizId(Long quizId);
+
+    List<QuizQuestion> findAllByQuiz(Quiz quiz);
+
+    void deleteAllByQuiz(Quiz quiz);
 }

--- a/src/main/java/com/likelion/server/domain/quiz/repository/QuizResultRepository.java
+++ b/src/main/java/com/likelion/server/domain/quiz/repository/QuizResultRepository.java
@@ -18,4 +18,6 @@ public interface QuizResultRepository extends JpaRepository<QuizResult, Long> {
     Optional<QuizResult> findByUserAndQuizId(User user, Long quizId);
 
     List<QuizResult> findAllByUserAndQuizIn(User user, List<Quiz> quizzes);
+
+    List<QuizResult> findAllByQuizIn(List<Quiz> quizzes);
 }


### PR DESCRIPTION
## 🔍 관련 이슈
<!--
- close #123
-->
- close #52 

<br>

## ✅ 작업 분류
- [x] 신규 기능
- [x] 기능 수정
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경
- [x] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
1. PdfService.delete()에서 권한 체크를 제거하여, deleteGroup 서비스가 S3 파일까지 강제로 삭제할 수 있도록 수정했습니다.
2. 수동 연쇄 삭제에 필요한 모든 리포지토리 쿼리 메서드를 추가했습니다.
3. LEADER(방장)용 그룹 삭제 API를 구현했습니다.
4. GroupServiceImpl에 deleteGroup 메서드를 구현했습니다.
5. 그룹과 관련된 모든 데이터 (PDF, 퀴즈, QA, 멤버 등)를 영구적으로 삭제합니다.

<br>

## 👥 전달사항
- LEADER 역할의 사용자만 이 API를 호출할 수 있으며, MEMBER가 호출할 경우 403 Forbidden 예외가 발생합니다. 
<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
<img width="758" height="437" alt="image" src="https://github.com/user-attachments/assets/596159b9-0c68-452a-a6fd-f275da44cd27" />
<img width="757" height="434" alt="image" src="https://github.com/user-attachments/assets/aaf83d60-284f-4277-9805-5c7f58192e7f" />

