### PR TITLE
🐛Bug: 멤버 퇴장시 그룹 랭킹이 업데이트되지 않는 버그 수정

### DIFF
--- a/src/main/java/com/likelion/server/domain/group/service/GroupServiceImpl.java
+++ b/src/main/java/com/likelion/server/domain/group/service/GroupServiceImpl.java
@@ -125,6 +125,7 @@ public class GroupServiceImpl implements GroupService {
         }
         deletePersonalQuizActivity(user, group);
         groupMemberRepository.delete(member);
+        recalculateRankPositions(group);
     }
 
     // 그룹삭제(LEADER)
@@ -274,6 +275,25 @@ public class GroupServiceImpl implements GroupService {
             return String.format("%d/%d (%d%%)", correct, total, percent);
         } else {
             return String.format("0/%d (0%%)", total);
+        }
+    }
+
+    private void recalculateRankPositions(Group group) {
+        List<GroupRanking> rankings = groupRankingRepository.findAllByGroupOrderByTotalScoreDesc(group);
+
+        int currentRank = 1;
+        int sameScoreCount = 0;
+        Integer previousScore = null;
+
+        for (GroupRanking rank : rankings) {
+            if (previousScore == null || !rank.getTotalScore().equals(previousScore)) {
+                currentRank += sameScoreCount;
+                sameScoreCount = 0;
+            }
+
+            rank.setRankPosition(currentRank);
+            sameScoreCount++;
+            previousScore = rank.getTotalScore();
         }
     }
 }

--- a/src/main/java/com/likelion/server/domain/user/web/dto/WrongNoteDetailResponse.java
+++ b/src/main/java/com/likelion/server/domain/user/web/dto/WrongNoteDetailResponse.java
@@ -46,6 +46,7 @@ public record WrongNoteDetailResponse(
     }
     // 틀린 문제 상세 DTO
     public record WrongQuestionDto(
+            @JsonProperty("quiz_question_id")
             Long id,
             String type,
             @JsonProperty("question_text") String questionText,


### PR DESCRIPTION
## 🔍 관련 이슈
<!--
- close #123
-->
- close #58 

<br>

## ✅ 작업 분류
- [ ] 신규 기능
- [ ] 기능 수정
- [x] 버그 수정
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
멤버 퇴장 서비스 로직에 recalculateRankPositions함수를 추가하여 랭킹이 다시 계산되도록 수정했습니다.

<br>

## 👥 전달사항
<!--
1. User 도메인 구조를 변경하였습니다.
2. User 도메인 사용자 닉네임 필드를 username -> nickname으로 변경하였습니다.
-->

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
