### PR TITLE
 Fix: 퀴즈 조회에 group_name, question_number 필드 추가

### DIFF
--- a/src/main/java/com/likelion/server/domain/quiz/web/dto/QuizDetailResponse.java
+++ b/src/main/java/com/likelion/server/domain/quiz/web/dto/QuizDetailResponse.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -29,6 +30,7 @@ public class QuizDetailResponse {
     public static class QuizInfo {
         private Long id;
         private Long pdf_id;
+        private String group_name;
         private String title;
         private String difficulty;
         private int round;
@@ -39,6 +41,7 @@ public class QuizDetailResponse {
             return QuizInfo.builder()
                     .id(quiz.getId())
                     .pdf_id(quiz.getPdf().getId())
+                    .group_name(quiz.getGroup().getName())
                     .title(quiz.getPdf().getFileName())
                     .difficulty(quiz.getDifficulty().name())
                     .round(quiz.getRound())
@@ -56,15 +59,17 @@ public class QuizDetailResponse {
     public static class QuestionInfo {
         private Long id;
         private String type;
+        private Integer question_number;
         private String question_text;
         private String correct_answer;
         private String explanation;
         private List<OptionInfo> options;
 
-        public static QuestionInfo fromEntity(QuizQuestion q) {
+        public static QuestionInfo fromEntity(QuizQuestion q, int index) {
             return QuestionInfo.builder()
                     .id(q.getId())
                     .type(convertTypeToKorean(q.getType()))
+                    .question_number(index + 1)
                     .question_text(q.getQuestionText())
                     .correct_answer(q.getCorrectAnswer())
                     .explanation(q.getExplanation())
@@ -72,6 +77,18 @@ public class QuizDetailResponse {
                             .map(OptionInfo::fromEntity)
                             .collect(Collectors.toList()))
                     .build();
+        }
+
+        public static List<QuestionInfo> fromEntityList(List<QuizQuestion> questions) {
+            if (questions == null || questions.isEmpty()) return List.of();
+
+            List<QuestionInfo> result = new ArrayList<>();
+
+            for (int i = 0; i < questions.size(); i++) {
+                result.add(fromEntity(questions.get(i), i)); // 순번 자동 부여
+            }
+
+            return result;
         }
 
         static String convertTypeToKorean(Type type) {
@@ -102,9 +119,7 @@ public class QuizDetailResponse {
     public static QuizDetailResponse fromEntities(Quiz quiz, List<QuizQuestion> questions) {
         return QuizDetailResponse.builder()
                 .quiz(QuizInfo.fromEntity(quiz))
-                .questions(questions.stream()
-                        .map(QuestionInfo::fromEntity)
-                        .collect(Collectors.toList()))
+                .questions(QuestionInfo.fromEntityList(questions))
                 .build();
     }
 }

--- a/src/main/java/com/likelion/server/domain/quiz/web/dto/QuizResultDetailResponse.java
+++ b/src/main/java/com/likelion/server/domain/quiz/web/dto/QuizResultDetailResponse.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 
 import java.time.LocalDateTime;
 import java.util.*;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
 import static com.likelion.server.domain.quiz.web.dto.QuizDetailResponse.QuestionInfo.convertTypeToKorean;
@@ -19,6 +20,7 @@ public record QuizResultDetailResponse(
     @Builder
     public record QuizResultInfo(
             Long quiz_id,
+            String group_name,
             Integer score,
             Integer correct_count,
             Integer total_questions,
@@ -29,6 +31,7 @@ public record QuizResultDetailResponse(
     public record AnswerInfo(
             Long quiz_result_id,
             Long question_id,
+            Integer question_number,
             String question_text,
             String type,
             String explanation,
@@ -48,6 +51,8 @@ public record QuizResultDetailResponse(
 
         Set<Long> seen = new HashSet<>();
 
+        AtomicInteger number = new AtomicInteger(1);
+
         List<AnswerInfo> answerInfos = allQuestions.stream()
                 .filter(q -> seen.add(q.getId()))
                 .map(q -> {
@@ -57,6 +62,7 @@ public record QuizResultDetailResponse(
                     return AnswerInfo.builder()
                             .quiz_result_id(result.getId())
                             .question_id(q.getId())
+                            .question_number(number.getAndIncrement())
                             .question_text(q.getQuestionText())
                             .type(convertTypeToKorean(q.getType()))
                             .explanation(q.getExplanation())
@@ -74,6 +80,7 @@ public record QuizResultDetailResponse(
         return QuizResultDetailResponse.builder()
                 .quiz_result(QuizResultInfo.builder()
                         .quiz_id(result.getQuiz().getId())
+                        .group_name(result.getQuiz().getGroup().getName())
                         .score(result.getScore())
                         .correct_count(result.getCorrectCount())
                         .total_questions(result.getQuiz().getTotalQuestions())


### PR DESCRIPTION
## 🔍 관련 이슈
- close #65 

<br>

## ✅ 작업 분류
- [ ] 신규 기능
- [x] 기능 수정
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
1. 퀴즈 결과, 정답 조회에 group_name, question_number 응답 추가
2. 상세 조회 시 group_name, question_number 응답 추가

<br>

## 👥 전달사항
1. QuizDetailResponse, QuizResultDetailResponse DTO 를 수정했습니다.

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
1. 퀴즈 결과 조회 API (quiz/result/{result_id})
<img width="877" height="941" alt="image" src="https://github.com/user-attachments/assets/db846c7a-546e-4a87-bf3e-e2ea820454d0" />


2. 퀴즈 상세 조회 API (quiz/{quiz_id})
<img width="896" height="971" alt="image" src="https://github.com/user-attachments/assets/c0e4dd06-c49e-4bf4-8052-c2ab9682b5d8" />
