### PR TITLE
♻️ Refac: 퀴즈 타입 형식 통일

### DIFF
--- a/src/main/java/com/likelion/server/domain/quiz/entity/enums/Type.java
+++ b/src/main/java/com/likelion/server/domain/quiz/entity/enums/Type.java
@@ -1,5 +1,20 @@
 package com.likelion.server.domain.quiz.entity.enums;
 
+import com.fasterxml.jackson.annotation.JsonValue;
+
 public enum Type {
-    OX, MULTIPLE_CHOICE, SHORT_ANSWER
+    OX("OX"),
+    MULTIPLE_CHOICE("객관식"),
+    SHORT_ANSWER("단답형");
+
+    private final String displayName;
+
+    Type(String displayName) {
+        this.displayName = displayName;
+    }
+
+    @JsonValue // ← JSON 직렬화 시 이 값을 사용
+    public String getDisplayName() {
+        return displayName;
+    }
 }

--- a/src/main/java/com/likelion/server/domain/quiz/web/dto/QuizDetailResponse.java
+++ b/src/main/java/com/likelion/server/domain/quiz/web/dto/QuizDetailResponse.java
@@ -68,7 +68,7 @@ public class QuizDetailResponse {
         public static QuestionInfo fromEntity(QuizQuestion q, int index) {
             return QuestionInfo.builder()
                     .id(q.getId())
-                    .type(convertTypeToKorean(q.getType()))
+                    .type(q.getType().getDisplayName())
                     .question_number(index + 1)
                     .question_text(q.getQuestionText())
                     .correct_answer(q.getCorrectAnswer())
@@ -89,14 +89,6 @@ public class QuizDetailResponse {
             }
 
             return result;
-        }
-
-        static String convertTypeToKorean(Type type) {
-            return switch (type) {
-                case OX -> "OX";
-                case MULTIPLE_CHOICE -> "객관식";
-                case SHORT_ANSWER -> "단답형";
-            };
         }
     }
 

--- a/src/main/java/com/likelion/server/domain/quiz/web/dto/QuizQaResponse.java
+++ b/src/main/java/com/likelion/server/domain/quiz/web/dto/QuizQaResponse.java
@@ -49,7 +49,7 @@ public record QuizQaResponse(
         public QuestionDto(QuizQuestion question, List<OptionDto> options) {
             this(
                     question.getId(),
-                    question.getType().toString(),
+                    question.getType().getDisplayName(),
                     question.getQuestionText(),
                     question.getCorrectAnswer(),
                     question.getExplanation(),

--- a/src/main/java/com/likelion/server/domain/quiz/web/dto/QuizResultDetailResponse.java
+++ b/src/main/java/com/likelion/server/domain/quiz/web/dto/QuizResultDetailResponse.java
@@ -10,8 +10,6 @@ import java.util.*;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 
-import static com.likelion.server.domain.quiz.web.dto.QuizDetailResponse.QuestionInfo.convertTypeToKorean;
-
 @Builder
 public record QuizResultDetailResponse(
         QuizResultInfo quiz_result,
@@ -64,7 +62,7 @@ public record QuizResultDetailResponse(
                             .question_id(q.getId())
                             .question_number(number.getAndIncrement())
                             .question_text(q.getQuestionText())
-                            .type(convertTypeToKorean(q.getType()))
+                            .type(q.getType().getDisplayName())
                             .explanation(q.getExplanation())
                             .options(q.getOptions() == null ? List.of() :
                                     q.getOptions().stream()


### PR DESCRIPTION
## 🔍 관련 이슈
- close #76 

<br>

## ✅ 작업 분류
- [ ] 신규 기능
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경
- [x] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
<!--
  ex) 
  1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴
-->
- 퀴즈 상세 조회가 포함된 API 에서 quiz_type 한글로 통일하기 위해 enum 내부 매서드를 제작하여 response에 적용하였습니다.

<br>

## 👥 전달사항
<!--
1. User 도메인 구조를 변경하였습니다.
2. User 도메인 사용자 닉네임 필드를 username -> nickname으로 변경하였습니다.
-->

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
<img width="681" height="439" alt="image" src="https://github.com/user-attachments/assets/5430d73f-90f5-4a71-b24d-beef73352c27" />

