### PR TITLE
:recycle: Refac: 익명 댓글 번호 부여 기능 구현

### DIFF
--- a/src/main/java/com/likelion/server/domain/qa/repository/QaCommentRepository.java
+++ b/src/main/java/com/likelion/server/domain/qa/repository/QaCommentRepository.java
@@ -10,8 +10,7 @@ public interface QaCommentRepository extends JpaRepository<QaComment, Long> {
     // 특정 게시글의 댓글 수 카운트
     Integer countByPost(QaPost post);
 
-    // 특정 게시글에 속한 모든 댓글 목록 조회
-    List<QaComment> findAllByPost(QaPost post);
-
     void deleteAllByPostIn(List<QaPost> allPosts);
+
+    List<QaComment> findAllByPostOrderByCreatedAtAsc(QaPost post);
 }

--- a/src/main/java/com/likelion/server/domain/qa/repository/QaPostRepository.java
+++ b/src/main/java/com/likelion/server/domain/qa/repository/QaPostRepository.java
@@ -7,8 +7,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 
 public interface QaPostRepository extends JpaRepository<QaPost, Long> {
-    // 특정 게시판에 속한 게시글 목록 조회
-    List<QaPost> findAllByBoard(QaBoard board);
 
     List<QaPost> findAllByBoardIn(List<QaBoard> boardsInGroup);
+
+    List<QaPost> findAllByBoardOrderByCreatedAtAsc(QaBoard board);
 }

--- a/src/main/java/com/likelion/server/domain/qa/service/QaServiceImpl.java
+++ b/src/main/java/com/likelion/server/domain/qa/service/QaServiceImpl.java
@@ -16,7 +16,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 @Service
 @Transactional(readOnly = true)
@@ -85,23 +88,34 @@ public class QaServiceImpl implements QaService {
     @Override
     public QaBoardRefreshResponse getBoard(Long quizId) {
 
-        // quiz_id로 QaBoard 조회
+        // 기본 데이터 조회
         QaBoard board = qaBoardRepository.findByQuizId(quizId)
                 .orElseThrow(QaNotFoundException::new);
+        List<QaPost> posts = qaPostRepository.findAllByBoardOrderByCreatedAtAsc(board);
 
-        // board의 모든 QaPost 조회
-        List<QaPost> posts = qaPostRepository.findAllByBoard(board);
+        List<QaBoardRefreshResponse.PostDto> postDtos = new ArrayList<>();
 
-        // 각 QaPost를 PostDto로 변환
-        List<QaBoardRefreshResponse.PostDto> postDtos = posts.stream()
-                .map(post -> {
-                    // 각 post의 댓글 수 조회
-                    Integer commentsCount = qaCommentRepository.countByPost(post);
-                    return new QaBoardRefreshResponse.PostDto(post, commentsCount);
-                })
-                .toList();
+        for (QaPost post : posts) {
+            // 익명 번호 매핑
+            Map<Long, Integer> anonymousMap = new HashMap<>();
+            int anonymousCounter = 1;
 
-        // return
+            User postWriter = post.getWriter();
+            QaBoardRefreshResponse.UserDto postUserDto;
+
+            if (post.getIsAnonymous()) {
+                anonymousMap.put(postWriter.getId(), anonymousCounter);
+                String nickname = "익명 " + anonymousMap.get(postWriter.getId());
+                postUserDto = new QaBoardRefreshResponse.UserDto(nickname);
+            } else {
+                postUserDto = new QaBoardRefreshResponse.UserDto(postWriter);
+            }
+
+            Integer commentsCount = qaCommentRepository.countByPost(post);
+
+            postDtos.add(new QaBoardRefreshResponse.PostDto(post, postUserDto, commentsCount));
+        }
+
         return new QaBoardRefreshResponse(board, postDtos);
     }
 }

--- a/src/main/java/com/likelion/server/domain/qa/web/dto/QaBoardRefreshResponse.java
+++ b/src/main/java/com/likelion/server/domain/qa/web/dto/QaBoardRefreshResponse.java
@@ -18,12 +18,10 @@ public record QaBoardRefreshResponse(
             @JsonProperty("comments_count") Integer commentsCount, // "comments_count": 3
             @JsonProperty("created_at") String createdAt
     ) {
-        public PostDto(QaPost post, Integer commentsCount) {
+        public PostDto(QaPost post, UserDto userDto, Integer commentsCount) {
             this(
                     post.getId(),
-                    post.getIsAnonymous()
-                            ? new UserDto("익명") // 익명일 경우
-                            : new UserDto(post.getWriter()), // 실명일 경우
+                    userDto,
                     commentsCount,
                     post.getCreatedAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
             );

--- a/src/main/java/com/likelion/server/domain/quiz/service/QuizServiceImpl.java
+++ b/src/main/java/com/likelion/server/domain/quiz/service/QuizServiceImpl.java
@@ -3,6 +3,8 @@ package com.likelion.server.domain.quiz.service;
 import com.likelion.server.domain.pdf.entity.Pdf;
 import com.likelion.server.domain.pdf.repository.PdfRepository;
 import com.likelion.server.domain.qa.entity.QaBoard;
+import com.likelion.server.domain.qa.entity.QaComment;
+import com.likelion.server.domain.qa.entity.QaPost;
 import com.likelion.server.domain.qa.exception.QaNotFoundException;
 import com.likelion.server.domain.qa.repository.QaBoardRepository;
 import com.likelion.server.domain.qa.repository.QaCommentRepository;
@@ -18,12 +20,16 @@ import com.likelion.server.domain.quiz.web.dto.CreateQuizRequest;
 import com.likelion.server.domain.quiz.web.dto.CreateQuizResponse;
 import com.likelion.server.domain.quiz.web.dto.QuizDetailResponse;
 import com.likelion.server.domain.quiz.web.dto.QuizQaResponse;
+import com.likelion.server.domain.user.entity.User;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Service
@@ -147,11 +153,10 @@ public class QuizServiceImpl implements QuizService {
     @Override
     public QuizQaResponse getQuizWithQa(Long quizId) {
 
-        // Quiz 조회
+        // Quiz DTO
         Quiz quiz = quizRepository.findById(quizId)
                 .orElseThrow(QuizNotFoundException::new);
 
-        // 질문 목록 조회
         List<QuizQaResponse.QuestionDto> questionDtos = quizQuestionRepository.findAllByQuizId(quizId)
                 .stream()
                 .map(question -> {
@@ -166,23 +171,55 @@ public class QuizServiceImpl implements QuizService {
                 .collect(Collectors.toList());
 
         QuizQaResponse.QuizDto quizDto = new QuizQaResponse.QuizDto(quiz, questionDtos);
-
+        // QA Board DTO
         QaBoard qaBoard = qaBoardRepository.findByQuizId(quizId)
-                .orElseThrow(() -> new QaNotFoundException());
+                .orElseThrow(QaNotFoundException::new);
 
-        // 게시글 목록 조회
-        List<QuizQaResponse.PostDto> postDtos = qaPostRepository.findAllByBoard(qaBoard)
-                .stream()
-                .map(post -> {
-                    // 댓글 목록 조회
-                    List<QuizQaResponse.CommentDto> commentDtos = qaCommentRepository.findAllByPost(post)
-                            .stream()
-                            .map(QuizQaResponse.CommentDto::new)
-                            .collect(Collectors.toList());
+        // 게시글/댓글 모두 생성순 정렬
+        List<QaPost> posts = qaPostRepository.findAllByBoardOrderByCreatedAtAsc(qaBoard);
+        List<QuizQaResponse.PostDto> postDtos = new ArrayList<>();
 
-                    return new QuizQaResponse.PostDto(post, commentDtos);
-                })
-                .collect(Collectors.toList());
+        for (QaPost post : posts) {
+
+            // 익명 번호 매핑 로직 (게시글마다 리셋)
+            Map<Long, Integer> anonymousMap = new HashMap<>();
+            int anonymousCounter = 1;
+
+            // 게시글 작성자 익명 처리
+            User postWriter = post.getWriter();
+            QuizQaResponse.UserNicknameDto postUserDto;
+
+            if (post.getIsAnonymous()) {
+                anonymousMap.put(postWriter.getId(), anonymousCounter++);
+                String nickname = "익명 " + anonymousMap.get(postWriter.getId());
+                postUserDto = new QuizQaResponse.UserNicknameDto(nickname);
+            } else {
+                postUserDto = new QuizQaResponse.UserNicknameDto(postWriter);
+            }
+
+            // 댓글 목록 조회 및 익명 처리
+            List<QaComment> comments = qaCommentRepository.findAllByPostOrderByCreatedAtAsc(post);
+            List<QuizQaResponse.CommentDto> commentDtos = new ArrayList<>();
+
+            for (QaComment comment : comments) {
+                User commentWriter = comment.getUser();
+                QuizQaResponse.UserNicknameDto commentUserDto;
+
+                if (comment.getIsAnonymous()) {
+                    if (!anonymousMap.containsKey(commentWriter.getId())) {
+                        anonymousMap.put(commentWriter.getId(), anonymousCounter++);
+                    }
+                    String nickname = "익명 " + anonymousMap.get(commentWriter.getId());
+                    commentUserDto = new QuizQaResponse.UserNicknameDto(nickname);
+                } else {
+                    commentUserDto = new QuizQaResponse.UserNicknameDto(commentWriter);
+                }
+
+                commentDtos.add(new QuizQaResponse.CommentDto(comment, commentUserDto));
+            }
+
+            postDtos.add(new QuizQaResponse.PostDto(post, postUserDto, commentDtos));
+        }
 
         QuizQaResponse.QaBoardDto qaBoardDto = new QuizQaResponse.QaBoardDto(qaBoard, postDtos);
         return new QuizQaResponse(quizDto, qaBoardDto);

--- a/src/main/java/com/likelion/server/domain/quiz/web/dto/QuizQaResponse.java
+++ b/src/main/java/com/likelion/server/domain/quiz/web/dto/QuizQaResponse.java
@@ -90,12 +90,10 @@ public record QuizQaResponse(
             @JsonProperty("created_at") String createdAt,
             List<CommentDto> comments
     ) {
-        public PostDto(QaPost post, List<CommentDto> comments) {
+        public PostDto(QaPost post, UserNicknameDto userDto, List<CommentDto> comments) {
             this(
                     post.getId(),
-                    post.getIsAnonymous()
-                            ? new UserNicknameDto("익명") // 익명일 경우
-                            : new UserNicknameDto(post.getWriter()), // 실명일 경우
+                    userDto,
                     post.getContent(),
                     post.getCreatedAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME),
                     comments
@@ -109,12 +107,10 @@ public record QuizQaResponse(
             String content,
             @JsonProperty("created_at") String createdAt
     ) {
-        public CommentDto(QaComment comment) {
+        public CommentDto(QaComment comment, UserNicknameDto userDto) {
             this(
                     comment.getId(),
-                    comment.getIsAnonymous()
-                            ? new UserNicknameDto("익명") // 익명일 경우
-                            : new UserNicknameDto(comment.getUser()), // 실명일 경우
+                    userDto,
                     comment.getContent(),
                     comment.getCreatedAt().format(DateTimeFormatter.ISO_LOCAL_DATE_TIME)
             );


### PR DESCRIPTION
## 🔍 관련 이슈
<!--
- close #123
-->
- close #72 

<br>

## ✅ 작업 분류
- [ ] 신규 기능
- [x] 기능 수정
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경
- [x] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
1.  **익명 번호 로직 변경**
    * 익명 번호는 게시판(`quizId`) 전체가 아닌, 각 '게시글(`postId`)'을 기준으로 새로 리셋됩니다.
    * `QuizServiceImpl`과 `QaServiceImpl`의 `for (QaPost post : ...)` 루프 내에서 `Map`과 `counter`를 매번 새로 초기화하도록 수정했습니다.

2.  **DTO 생성자 수정**
    * 서비스 레이어에서 익명 닉네임을 생성하여 DTO로 주입하기 위해, `QuizQaResponse`와 `QaBoardRefreshResponse`의 생성자 로직을 수정했습니다.
    * 기존: DTO 내부에서 `new UserDto(user)` 호출
    * 변경: 서비스에서 생성한 `UserDto`를 파라미터로 주입받음

<br>

## 👥 전달사항
<!--
1. User 도메인 구조를 변경하였습니다.
2. User 도메인 사용자 닉네임 필드를 username -> nickname으로 변경하였습니다.
-->

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
<img width="494" height="651" alt="image" src="https://github.com/user-attachments/assets/d1fb81cf-4aac-4800-af5a-b61c183b2a24" />
