### PR TITLE
✨ Feat: 사용자 생성 퀴즈 API 구현

### DIFF
--- a/src/main/java/com/likelion/server/domain/quiz/entity/enums/Type.java
+++ b/src/main/java/com/likelion/server/domain/quiz/entity/enums/Type.java
@@ -17,4 +17,13 @@ public enum Type {
     public String getDisplayName() {
         return displayName;
     }
+
+    public static Type fromKorean(String value) {
+        return switch (value) {
+            case "객관식" -> MULTIPLE_CHOICE;
+            case "단답형" -> SHORT_ANSWER;
+            case "OX", "O,X", "O X" -> OX; // OX 입력 변형도 허용
+            default -> throw new IllegalArgumentException("잘못된 문제 유형: " + value);
+        };
+    }
 }

--- a/src/main/java/com/likelion/server/domain/quiz/service/QuizResultService.java
+++ b/src/main/java/com/likelion/server/domain/quiz/service/QuizResultService.java
@@ -36,7 +36,7 @@ public class QuizResultService {
                 .orElseThrow(() -> new IllegalArgumentException("해당 퀴즈를 찾을 수 없습니다."));
 
         User user = em.getReference(User.class, userId);
-        Group group = quiz.getPdf().getGroup();
+        Group group = quiz.getGroup();
 
         QuizResult quizResult = request.toEntity(quiz, user, group);
 

--- a/src/main/java/com/likelion/server/domain/quiz/service/QuizService.java
+++ b/src/main/java/com/likelion/server/domain/quiz/service/QuizService.java
@@ -1,17 +1,20 @@
 package com.likelion.server.domain.quiz.service;
 
-import com.likelion.server.domain.quiz.web.dto.CreateQuizRequest;
-import com.likelion.server.domain.quiz.web.dto.CreateQuizResponse;
-import com.likelion.server.domain.quiz.web.dto.QuizDetailResponse;
-import com.likelion.server.domain.quiz.web.dto.QuizQaResponse;
+import com.likelion.server.domain.quiz.web.dto.*;
 import org.springframework.transaction.annotation.Transactional;
 
 public interface QuizService {
+
+    // AI 생성 퀴즈
     CreateQuizResponse createQuiz(Long userId, CreateQuizRequest request);
 
+    // 사용자 생성 퀴즈
+    CreateQuizResponse createUserQuiz(Long userId, CreateUserQuizRequest request);
+
+    // 퀴즈 상세 조회
     QuizDetailResponse getQuizDetail(Long quizId);
 
-    // 3. 시험지+QA 게시판 통합 조회
+    // 시험지+QA 게시판 통합 조회
     @Transactional(readOnly = true) // 조회이므로 readOnly = true
     QuizQaResponse getQuizWithQa(Long quizId);
 }

--- a/src/main/java/com/likelion/server/domain/quiz/service/QuizServiceImpl.java
+++ b/src/main/java/com/likelion/server/domain/quiz/service/QuizServiceImpl.java
@@ -1,5 +1,6 @@
 package com.likelion.server.domain.quiz.service;
 
+import com.likelion.server.domain.group.entity.Group;
 import com.likelion.server.domain.pdf.entity.Pdf;
 import com.likelion.server.domain.pdf.repository.PdfRepository;
 import com.likelion.server.domain.qa.entity.QaBoard;
@@ -8,16 +9,15 @@ import com.likelion.server.domain.qa.repository.QaBoardRepository;
 import com.likelion.server.domain.qa.repository.QaCommentRepository;
 import com.likelion.server.domain.qa.repository.QaPostRepository;
 import com.likelion.server.domain.quiz.entity.Quiz;
+import com.likelion.server.domain.quiz.entity.QuizOption;
 import com.likelion.server.domain.quiz.entity.QuizQuestion;
 import com.likelion.server.domain.quiz.entity.enums.Difficulty;
+import com.likelion.server.domain.quiz.entity.enums.Type;
 import com.likelion.server.domain.quiz.exception.*;
 import com.likelion.server.domain.quiz.repository.QuizOptionRepository;
 import com.likelion.server.domain.quiz.repository.QuizRepository;
 import com.likelion.server.domain.quiz.repository.QuizQuestionRepository;
-import com.likelion.server.domain.quiz.web.dto.CreateQuizRequest;
-import com.likelion.server.domain.quiz.web.dto.CreateQuizResponse;
-import com.likelion.server.domain.quiz.web.dto.QuizDetailResponse;
-import com.likelion.server.domain.quiz.web.dto.QuizQaResponse;
+import com.likelion.server.domain.quiz.web.dto.*;
 import jakarta.persistence.EntityManager;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -74,8 +74,8 @@ public class QuizServiceImpl implements QuizService {
                 .build();
     }
 
-
-    // 1. 퀴즈 생성
+///////////////////////////////////////////////////////////////////////////////////
+    // 퀴즈 생성 1 - AI
     @Override
     public CreateQuizResponse createQuiz(Long userId, CreateQuizRequest request) {
 
@@ -124,6 +124,69 @@ public class QuizServiceImpl implements QuizService {
         }
 
         // 응답 DTO 변환
+        return CreateQuizResponse.fromEntity(quiz, qaBoard);
+    }
+
+
+    // 퀴즈 생성 2 - 사용자
+    @Override
+    public CreateQuizResponse createUserQuiz(Long userId, CreateUserQuizRequest request) {
+        // 그룹 유효성 검증
+        Group group = em.find(Group.class, request.getGroup_id());
+        if (group == null) throw new QuizGroupNotFoundException();
+
+
+        List<String> types = request.getQuestions().stream()
+                .map(CreateUserQuizRequest.UserQuestionRequest::getType)
+                .distinct()
+                .toList();
+
+        // Quiz 엔티티 생성 (AI·PDF 없이)
+        Quiz quiz = Quiz.builder()
+                .group(group)
+                .title(request.getTitle())
+                .round(1)
+                .totalQuestions(request.getQuestions().size())
+                .questionTypes(String.join(",", types))
+                .build();
+
+        quizRepository.saveAndFlush(quiz);
+
+        // 각 문제 저장
+        for (CreateUserQuizRequest.UserQuestionRequest q : request.getQuestions()) {
+            Type type = Type.fromKorean(q.getType());
+
+            QuizQuestion question = QuizQuestion.builder()
+                    .quiz(quiz)
+                    .type(type)
+                    .questionText(q.getQuestion_text())
+                    .correctAnswer(q.getCorrect_answer())
+                    .explanation(q.getExplanation())
+                    .build();
+
+            quizQuestionRepository.save(question);
+
+            // 객관식 보기 저장
+            if (type == Type.MULTIPLE_CHOICE && q.getOptions() != null) {
+                for (CreateUserQuizRequest.OptionRequest opt : q.getOptions()) {
+                    QuizOption option = QuizOption.builder()
+                            .question(question)
+                            .optionText(opt.getOption_text())
+                            .build();
+                    quizOptionRepository.save(option);
+                }
+            }
+        }
+
+        // QA 게시판 자동 생성
+        QaBoard qaBoard = QaBoard.builder()
+                .quiz(quiz)
+                .group(group)
+                .boardName(request.getTitle() + " (made)")
+                .build();
+        qaBoardRepository.save(qaBoard);
+
+        // 응답 반환
         return CreateQuizResponse.fromEntity(quiz, qaBoard);
     }
 

--- a/src/main/java/com/likelion/server/domain/quiz/web/controller/QuizController.java
+++ b/src/main/java/com/likelion/server/domain/quiz/web/controller/QuizController.java
@@ -3,6 +3,7 @@ package com.likelion.server.domain.quiz.web.controller;
 import com.likelion.server.domain.quiz.service.QuizService;
 import com.likelion.server.domain.quiz.web.dto.CreateQuizRequest;
 import com.likelion.server.domain.quiz.web.dto.CreateQuizResponse;
+import com.likelion.server.domain.quiz.web.dto.CreateUserQuizRequest;
 import com.likelion.server.domain.quiz.web.dto.QuizDetailResponse;
 import com.likelion.server.domain.quiz.web.dto.QuizQaResponse;
 import com.likelion.server.global.response.SuccessResponse;
@@ -17,12 +18,23 @@ public class QuizController {
 
     private final QuizService quizService;
 
+    // AI 생성
     @PostMapping("/create")
     public SuccessResponse<CreateQuizResponse> createQuiz(
             @AuthenticationPrincipal(expression = "id") Long userId,
             @RequestBody CreateQuizRequest request
     ) {
         CreateQuizResponse data = quizService.createQuiz(userId, request);
+        return SuccessResponse.created(data);
+    }
+
+    // 사용자 직접 생성
+    @PostMapping("/user/create")
+    public SuccessResponse<CreateQuizResponse> createUserQuiz(
+            @AuthenticationPrincipal(expression = "id") Long userId,
+            @RequestBody CreateUserQuizRequest request
+    ) {
+        CreateQuizResponse data = quizService.createUserQuiz(userId, request);
         return SuccessResponse.created(data);
     }
 

--- a/src/main/java/com/likelion/server/domain/quiz/web/dto/CreateQuizResponse.java
+++ b/src/main/java/com/likelion/server/domain/quiz/web/dto/CreateQuizResponse.java
@@ -29,9 +29,9 @@ public class CreateQuizResponse {
     public static CreateQuizResponse fromEntity(Quiz quiz, QaBoard qaBoard) {
         return CreateQuizResponse.builder()
                 .id(quiz.getId())
-                .pdf_id(quiz.getPdf().getId())
+                .pdf_id(quiz.getPdf() != null ? quiz.getPdf().getId() : null)
                 .round(quiz.getRound())
-                .difficulty(quiz.getDifficulty().name())
+                .difficulty(quiz.getDifficulty() != null ? quiz.getDifficulty().name() : null)
                 .question_types(List.of(quiz.getQuestionTypes().split(",")))
                 .total_questions(quiz.getTotalQuestions())
                 .qa_board(

--- a/src/main/java/com/likelion/server/domain/quiz/web/dto/CreateUserQuizRequest.java
+++ b/src/main/java/com/likelion/server/domain/quiz/web/dto/CreateUserQuizRequest.java
@@ -1,0 +1,35 @@
+package com.likelion.server.domain.quiz.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class CreateUserQuizRequest {
+    private Long group_id;
+    private String title;
+    private List<UserQuestionRequest> questions;
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class UserQuestionRequest {
+        private String type;  // "OX", "객관식", "단답형"
+        private Integer question_number;
+        private String question_text;
+        private String correct_answer;
+        private String explanation;
+        private List<OptionRequest> options; // 객관식일 때만 존재
+    }
+
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class OptionRequest {
+        private String option_text;
+    }
+}

--- a/src/main/java/com/likelion/server/domain/quiz/web/dto/QuizDetailResponse.java
+++ b/src/main/java/com/likelion/server/domain/quiz/web/dto/QuizDetailResponse.java
@@ -40,10 +40,10 @@ public class QuizDetailResponse {
         public static QuizInfo fromEntity(Quiz quiz) {
             return QuizInfo.builder()
                     .id(quiz.getId())
-                    .pdf_id(quiz.getPdf().getId())
+                    .pdf_id(quiz.getPdf() != null ? quiz.getPdf().getId() : null)
                     .group_name(quiz.getGroup().getName())
-                    .title(quiz.getPdf().getFileName())
-                    .difficulty(quiz.getDifficulty().name())
+                    .title(quiz.getPdf() != null ? quiz.getPdf().getFileName() : quiz.getTitle())
+                    .difficulty(quiz.getDifficulty() != null ? quiz.getDifficulty().name() : null)
                     .round(quiz.getRound())
                     .total_questions(quiz.getTotalQuestions())
                     .createdAt(quiz.getCreatedAt())

--- a/src/main/java/com/likelion/server/domain/quiz/web/dto/QuizQaResponse.java
+++ b/src/main/java/com/likelion/server/domain/quiz/web/dto/QuizQaResponse.java
@@ -29,10 +29,10 @@ public record QuizQaResponse(
             this(
                     quiz.getId(),
                     quiz.getTitle(),
-                    quiz.getDifficulty().getKorean(),
+                    quiz.getDifficulty() != null ? quiz.getDifficulty().getKorean() : null,
                     quiz.getRound(),
                     quiz.getTotalQuestions(),
-                    quiz.getPdf().getGroup().getName(),
+                    quiz.getGroup() != null ? quiz.getGroup().getName() : null,
                     questions
             );
         }


### PR DESCRIPTION
## 🔍 관련 이슈
- close #79 

<br>

## ✅ 작업 분류
- [x] 신규 기능
- [ ] 기능 수정
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
1. 사용자 직접 생성 퀴즈 API (POST /quiz/user/create) 구현
- PDF 없이 group_id, title, questions[] 기반으로 퀴즈 생성
- 문제 유형: "OX", "객관식", "단답형" 지원
- 객관식 문제일 경우 options[] 저장 로직 추가

2. QuizServiceImpl.createUserQuiz() 신규 메서드 작성
- questionTypes 필드 자동 추출 및 저장 ("OX,객관식,단답형")
- QA 게시판(QaBoard) 자동 생성 로직 추가
3. QuizController에 /quiz/user/create 엔드포인트 추가
4. Type.fromKorean() 메서드 추가 ("OX", "객관식", "단답형" 매핑 지원)
5. CreateQuizResponse, QuizInfo 등에서 null-safe 처리
- quiz.getPdf() → quiz.getTitle() fallback
- quiz.getDifficulty() nullable 대응
- questionTypes null-safe 분기

<br>

## 👥 전달사항
- AI 기반 퀴즈 생성(createQuiz)과는 별개의 로직입니다.
- PDF 및 AiQuizGenerator 의존성 없음.
- 이후 /quiz/start 메서드에서 quiz.getGroup() 으로 변경 필요 (적용 완료).

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
<img width="876" height="1059" alt="image" src="https://github.com/user-attachments/assets/585eea22-5813-4622-bb45-f4886c4d90df" />

