### PR TITLE
♻️ Refac: JWT 관련 exception 로직 구현

### DIFF
--- a/src/main/java/com/likelion/server/global/config/SecurityConfig.java
+++ b/src/main/java/com/likelion/server/global/config/SecurityConfig.java
@@ -21,6 +21,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class SecurityConfig {
     private final JwtTokenProvider jwtTokenProvider;
     private final JwtUserDetailsService userDetailsService;
+    private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -43,9 +44,10 @@ public class SecurityConfig {
                         .permitAll()
                         .anyRequest().authenticated()
                 )
+
                 // jwt 필터 추가
                 .addFilterBefore(
-                        new JwtAuthenticationFilter(jwtTokenProvider, userDetailsService),
+                        new JwtAuthenticationFilter(jwtTokenProvider, userDetailsService, jwtAuthenticationEntryPoint),
                         UsernamePasswordAuthenticationFilter.class
                 );
 

--- a/src/main/java/com/likelion/server/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/likelion/server/global/exception/GlobalExceptionHandler.java
@@ -1,8 +1,13 @@
 package com.likelion.server.global.exception;
 
+import com.likelion.server.global.exception.jwt.JwtExpiredException;
+import com.likelion.server.global.exception.jwt.JwtInvalidException;
+import com.likelion.server.global.exception.jwt.JwtMalformedException;
+import com.likelion.server.global.exception.jwt.JwtUnsupportedException;
 import com.likelion.server.global.response.ErrorResponse;
 import com.likelion.server.global.response.code.GlobalErrorCode;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
@@ -86,6 +91,35 @@ public class GlobalExceptionHandler {
         log.error("Exception Error ", e);
         ErrorResponse error = ErrorResponse.of(GlobalErrorCode.SERVER_ERROR);
         return ResponseEntity.status(error.getHttpStatus()).body(error);
+    }
+
+    //* JWT */
+    // JWT 만료
+    @ExceptionHandler(JwtExpiredException.class)
+    public ResponseEntity<ErrorResponse<?>> handleJwtExpiredException(JwtExpiredException e) {
+        ErrorResponse<?> error = ErrorResponse.of("JWT_401_EXPIRED", e.getMessage(), HttpStatus.UNAUTHORIZED.value());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(error);
+    }
+
+    // 잘못된 토큰
+    @ExceptionHandler(JwtInvalidException.class)
+    public ResponseEntity<ErrorResponse<?>> handleJwtInvalidException(JwtInvalidException e) {
+        ErrorResponse<?> error = ErrorResponse.of("JWT_401_INVALID", e.getMessage(), HttpStatus.UNAUTHORIZED.value());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(error);
+    }
+
+    // 지원하지 않는 형식
+    @ExceptionHandler(JwtUnsupportedException.class)
+    public ResponseEntity<ErrorResponse<?>> handleJwtUnsupportedException(JwtUnsupportedException e) {
+        ErrorResponse<?> error = ErrorResponse.of("JWT_401_UNSUPPORTED", e.getMessage(), HttpStatus.UNAUTHORIZED.value());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(error);
+    }
+
+    // 손상된 구조
+    @ExceptionHandler(JwtMalformedException.class)
+    public ResponseEntity<ErrorResponse<?>> handleJwtMalformedException(JwtMalformedException e) {
+        ErrorResponse<?> error = ErrorResponse.of("JWT_401_MALFORMED", e.getMessage(), HttpStatus.UNAUTHORIZED.value());
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body(error);
     }
 
 }

--- a/src/main/java/com/likelion/server/global/exception/jwt/JwtExpiredException.java
+++ b/src/main/java/com/likelion/server/global/exception/jwt/JwtExpiredException.java
@@ -1,0 +1,10 @@
+package com.likelion.server.global.exception.jwt;
+
+import com.likelion.server.global.exception.BaseException;
+import com.likelion.server.global.response.code.JwtErrorCode;
+
+public class JwtExpiredException extends BaseException {
+    public JwtExpiredException() {
+        super(JwtErrorCode.JWT_401_EXPIRED);
+    }
+}

--- a/src/main/java/com/likelion/server/global/exception/jwt/JwtInvalidException.java
+++ b/src/main/java/com/likelion/server/global/exception/jwt/JwtInvalidException.java
@@ -1,0 +1,10 @@
+package com.likelion.server.global.exception.jwt;
+
+import com.likelion.server.global.exception.BaseException;
+import com.likelion.server.global.response.code.JwtErrorCode;
+
+public class JwtInvalidException extends BaseException {
+    public JwtInvalidException() {
+        super(JwtErrorCode.JWT_401_INVALID);
+    }
+}

--- a/src/main/java/com/likelion/server/global/exception/jwt/JwtMalformedException.java
+++ b/src/main/java/com/likelion/server/global/exception/jwt/JwtMalformedException.java
@@ -1,0 +1,11 @@
+package com.likelion.server.global.exception.jwt;
+
+import com.likelion.server.global.exception.BaseException;
+import com.likelion.server.global.response.code.JwtErrorCode;
+
+
+public class JwtMalformedException extends BaseException {
+    public JwtMalformedException() {
+        super(JwtErrorCode.JWT_401_MALFORMED);
+    }
+}

--- a/src/main/java/com/likelion/server/global/exception/jwt/JwtUnsupportedException.java
+++ b/src/main/java/com/likelion/server/global/exception/jwt/JwtUnsupportedException.java
@@ -1,0 +1,10 @@
+package com.likelion.server.global.exception.jwt;
+
+import com.likelion.server.global.exception.BaseException;
+import com.likelion.server.global.response.code.JwtErrorCode;
+
+public class JwtUnsupportedException extends BaseException {
+    public JwtUnsupportedException() {
+        super(JwtErrorCode.JWT_401_UNSUPPORTED);
+    }
+}

--- a/src/main/java/com/likelion/server/global/jwt/JwtAuthenticationEntryPoint.java
+++ b/src/main/java/com/likelion/server/global/jwt/JwtAuthenticationEntryPoint.java
@@ -1,24 +1,55 @@
 package com.likelion.server.global.jwt;
 
-import jakarta.servlet.http.HttpServletRequest;
-import jakarta.servlet.http.HttpServletResponse;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.likelion.server.global.exception.BaseException;
+import com.likelion.server.global.response.BaseResponse;
+import com.likelion.server.global.response.ErrorResponse;
+import jakarta.servlet.http.*;
+import org.springframework.http.HttpStatus;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
 
-/**
- * 인증 실패 시 401 Unauthorized 반환
- */
+
 @Component
 public class JwtAuthenticationEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     @Override
     public void commence(HttpServletRequest request,
                          HttpServletResponse response,
-                         AuthenticationException authException) throws IOException {
+                         AuthenticationException authException)
+            throws IOException {
 
-        response.sendError(HttpServletResponse.SC_UNAUTHORIZED, "인증이 필요합니다.");
+        // 필터에서 설정한 예외 객체 가져오기 (JwtAuthenticationFilter에서 setAttribute로 전달 가능)
+        Exception ex = (Exception) request.getAttribute("jwt_exception");
+
+        ErrorResponse<?> errorResponse;
+
+        // BaseException (JwtExpiredException, JwtInvalidException 등) 인 경우
+        if (ex instanceof BaseException baseEx) {
+            errorResponse = ErrorResponse.of(
+                    baseEx.getErrorCode().getCode(),
+                    baseEx.getMessage(),
+                    baseEx.getErrorCode().getHttpStatus()
+            );
+            response.setStatus(baseEx.getErrorCode().getHttpStatus());
+        }
+        // 토큰 누락, 형식 불일치 등 일반적인 Authentication 예외
+        else {
+            errorResponse = ErrorResponse.of(
+                    "JWT_401_UNAUTHORIZED",
+                    "인증이 필요합니다. (토큰이 없거나 잘못되었습니다.)",
+                    HttpStatus.UNAUTHORIZED.value()
+            );
+            response.setStatus(HttpStatus.UNAUTHORIZED.value());
+        }
+
+        // JSON 형태로 클라이언트에 응답
+        response.setContentType("application/json; charset=UTF-8");
+        objectMapper.writeValue(response.getWriter(), errorResponse);
     }
 }

--- a/src/main/java/com/likelion/server/global/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/com/likelion/server/global/jwt/JwtAuthenticationFilter.java
@@ -1,12 +1,15 @@
 package com.likelion.server.global.jwt;
 
+import com.likelion.server.global.exception.BaseException;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.*;
+import org.springframework.security.web.AuthenticationEntryPoint;
 import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 
@@ -15,16 +18,12 @@ import java.io.IOException;
  * - 요청 헤더의 Authorization에서 JWT 토큰 추출
  * - 유효성 검증 후 SecurityContext에 인증 저장
  */
+@RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtTokenProvider jwtTokenProvider;
     private final JwtUserDetailsService userDetailsService;
-
-    public JwtAuthenticationFilter(JwtTokenProvider jwtTokenProvider,
-                                   JwtUserDetailsService userDetailsService) {
-        this.jwtTokenProvider = jwtTokenProvider;
-        this.userDetailsService = userDetailsService;
-    }
+    private final AuthenticationEntryPoint authenticationEntryPoint; // ✅ 추가
 
     @Override
     protected void doFilterInternal(HttpServletRequest request,
@@ -32,23 +31,36 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                                     FilterChain filterChain)
             throws ServletException, IOException {
 
-        String header = request.getHeader("Authorization");
+        try {
+            String token = resolveToken(request);
 
-        if (header != null && header.startsWith("Bearer ")) {
-            String token = header.substring(7);
+            if (token != null) {
+                // ⛳ 여기서 JwtTokenProvider가 Jwt*Exception들을 throw
+                jwtTokenProvider.validateToken(token);
 
-            if (jwtTokenProvider.validateToken(token)) {
                 String nickname = jwtTokenProvider.getNicknameFromToken(token);
                 UserDetails userDetails = userDetailsService.loadUserByUsername(nickname);
 
                 UsernamePasswordAuthenticationToken authentication =
-                        new UsernamePasswordAuthenticationToken(
-                                userDetails, null, userDetails.getAuthorities());
-
+                        new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
                 SecurityContextHolder.getContext().setAuthentication(authentication);
             }
-        }
 
-        filterChain.doFilter(request, response);
+            filterChain.doFilter(request, response);
+
+        } catch (BaseException e) { // JwtExpiredException, JwtInvalidException 등
+            // EntryPoint가 ErrorResponse(JSON)로 응답할 수 있게 예외를 전달
+            request.setAttribute("jwt_exception", e); // ✅ EntryPoint에서 꺼내 쓸 키
+            SecurityContextHolder.clearContext();
+            authenticationEntryPoint.commence(
+                    request, response,
+                    new org.springframework.security.authentication.InsufficientAuthenticationException(e.getMessage(), e)
+            );
+        }
+    }
+
+    private String resolveToken(HttpServletRequest request) {
+        String bearer = request.getHeader("Authorization");
+        return (bearer != null && bearer.startsWith("Bearer ")) ? bearer.substring(7) : null;
     }
 }

--- a/src/main/java/com/likelion/server/global/jwt/JwtTokenProvider.java
+++ b/src/main/java/com/likelion/server/global/jwt/JwtTokenProvider.java
@@ -1,5 +1,9 @@
 package com.likelion.server.global.jwt;
 
+import com.likelion.server.global.exception.jwt.JwtExpiredException;
+import com.likelion.server.global.exception.jwt.JwtInvalidException;
+import com.likelion.server.global.exception.jwt.JwtMalformedException;
+import com.likelion.server.global.exception.jwt.JwtUnsupportedException;
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
 import org.springframework.stereotype.Component;
@@ -8,14 +12,13 @@ import javax.crypto.SecretKey;
 import java.security.Key;
 import java.util.Date;
 
-/**
- * JWT 토큰 생성 / 검증 유틸리티 (parserBuilder 없는 버전)
- */
+//JWT 토큰 생성 / 검증 유틸리티
 @Component
 public class JwtTokenProvider {
 
-    // 비밀키 (256bit 이상 권장)
+    // 비밀키
     private static final String SECRET_KEY = "QROOM_SECRET_KEY_QROOM_SECRET_KEY_1234567891011";
+
     // 토큰 유효기간
     private static final long ACCESS_TOKEN_EXPIRATION = 1000 * 60 * 60;       // 1시간
     private static final long REFRESH_TOKEN_EXPIRATION = 1000 * 60 * 60 * 24 * 7; // 7일
@@ -44,17 +47,7 @@ public class JwtTokenProvider {
                 .compact();
     }
 
-    /** 2. 토큰에서 닉네임(subject) 추출 */
-    public String getNicknameFromToken(String token) {
-        return Jwts.parser()
-                .verifyWith((SecretKey) key)
-                .build()
-                .parseSignedClaims(token)
-                .getPayload()
-                .getSubject();
-    }
-
-    /** 3. 토큰 유효성 검증 */
+    /** 2. 토큰 유효성 검증 */
     public boolean validateToken(String token) {
         try {
             Jwts.parser()
@@ -62,11 +55,43 @@ public class JwtTokenProvider {
                     .build()
                     .parseSignedClaims(token);
             return true;
-        } catch (io.jsonwebtoken.ExpiredJwtException e) {
-            System.out.println("❌ JWT 만료됨");
-        } catch (Exception e) {
-            System.out.println("❌ JWT 검증 실패: " + e.getMessage());
+        }  catch (ExpiredJwtException e) {
+            System.err.println("❌ JWT 만료됨: " + e.getMessage());
+            throw new JwtExpiredException();
+
+        } catch (UnsupportedJwtException e) {
+            System.err.println("❌ 지원되지 않는 JWT 형식: " + e.getMessage());
+            throw new JwtUnsupportedException();
+
+        } catch (MalformedJwtException e) {
+            System.err.println("❌ JWT 구조 손상됨: " + e.getMessage());
+            throw new JwtMalformedException();
+
+        } catch (SignatureException | IllegalArgumentException e) {
+            System.err.println("❌ JWT 서명 불일치 또는 잘못된 토큰: " + e.getMessage());
+            throw new JwtInvalidException();
+
+        } catch (JwtException e) {
+            System.err.println("❌ JWT 파싱 중 일반 예외: " + e.getMessage());
+            throw new JwtInvalidException();
         }
-        return false;
+    }
+
+    /** 3. 토큰에서 닉네임(subject) 추출 */
+    public String getNicknameFromToken(String token) {
+        try {
+            return Jwts.parser()
+                    .verifyWith((SecretKey) key)
+                    .build()
+                    .parseSignedClaims(token)
+                    .getPayload()
+                    .getSubject();
+        } catch (ExpiredJwtException e) {
+            System.err.println("❌ Access Token 만료: " + e.getMessage());
+            throw new JwtExpiredException();
+        } catch (JwtException e) {
+            System.err.println("❌ JWT 파싱 실패: " + e.getMessage());
+            throw new JwtInvalidException();
+        }
     }
 }

--- a/src/main/java/com/likelion/server/global/response/ErrorResponse.java
+++ b/src/main/java/com/likelion/server/global/response/ErrorResponse.java
@@ -47,4 +47,15 @@ public class ErrorResponse<T> extends BaseResponse {
                 .data(data)
                 .build();
     }
+
+    public static <T> ErrorResponse<T> of(String code, String message, int httpStatus) {
+        return ErrorResponse.<T>builder()
+                .code(code)
+                .httpStatus(httpStatus)
+                .message(message)
+                .data(null)
+                .build();
+    }
+
+
 }

--- a/src/main/java/com/likelion/server/global/response/code/JwtErrorCode.java
+++ b/src/main/java/com/likelion/server/global/response/code/JwtErrorCode.java
@@ -1,0 +1,21 @@
+package com.likelion.server.global.response.code;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import static com.likelion.server.global.constant.StaticValue.*;
+
+@Getter
+@AllArgsConstructor
+public enum JwtErrorCode implements BaseResponseCode {
+
+    // 인증 관련
+    JWT_401_EXPIRED("JWT_401_EXPIRED", UNAUTHORIZED, "JWT 토큰이 만료되었습니다."),
+    JWT_401_INVALID("JWT_401_INVALID", UNAUTHORIZED, "유효하지 않은 JWT 토큰입니다."),
+    JWT_401_UNSUPPORTED("JWT_401_UNSUPPORTED", UNAUTHORIZED, "지원되지 않는 JWT 토큰 형식입니다."),
+    JWT_401_MALFORMED("JWT_401_MALFORMED", UNAUTHORIZED, "JWT 구조가 올바르지 않습니다.");
+
+    private final String code;
+    private final int httpStatus;
+    private final String message;
+}


### PR DESCRIPTION
## 🔍 관련 이슈
- close #71 

<br>

## ✅ 작업 분류
- [x] 신규 기능
- [x] 기능 수정
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경
- [x] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
1. BaseException 리팩토링
→ super(message) 추가 및 code, message, httpStatus 필드 통합 관리

2. Jwt*Exception (Expired, Invalid, Unsupported, Malformed) 커스텀 예외 클래스 구현
→ 각 예외별 기본 메시지 지정

3. JwtAuthenticationEntryPoint 수정
→ BaseException 기반으로 JWT 예외 메시지 JSON 응답 처리

4. SecurityConfig 수정
→ JwtAuthenticationEntryPoint 등록 및 필터 체인 연결

5. 전역 예외 처리 (GlobalExceptionHandler) 정리
→ 불필요한 JWT 핸들러 제거, EntryPoint 중심으로 예외 응답 일원화

<br>

## 👥 전달사항
- JWT 관련 예외 발생 시 GlobalExceptionHandler가 아닌 JwtAuthenticationEntryPoint 에서 JSON 형태로 에러 반환하도록 구조 변경

- 모든 JWT 오류 응답이 ErrorResponse 포맷으로 통일됨


<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
<img width="423" height="204" alt="image" src="https://github.com/user-attachments/assets/eab3cd6e-7f22-435c-9d6d-1cf724ccdc43" />


