### PR TITLE
🚨 Fix: 퀴즈 사용자 생성 시 difficulty 값 중으로 설정

### DIFF
--- a/src/main/java/com/likelion/server/domain/quiz/service/QuizServiceImpl.java
+++ b/src/main/java/com/likelion/server/domain/quiz/service/QuizServiceImpl.java
@@ -157,6 +157,7 @@ public class QuizServiceImpl implements QuizService {
                 .group(group)
                 .title(request.getTitle())
                 .round(1)
+                .difficulty(Difficulty.중)
                 .totalQuestions(request.getQuestions().size())
                 .questionTypes(String.join(",", types))
                 .build();

--- a/src/main/java/com/likelion/server/domain/user/web/dto/WrongNoteDetailResponse.java
+++ b/src/main/java/com/likelion/server/domain/user/web/dto/WrongNoteDetailResponse.java
@@ -37,7 +37,7 @@ public record WrongNoteDetailResponse(
                     quiz.getTitle(),
                     quiz.getGroup().getName(),
                     quiz.getRound(),
-                    quiz.getDifficulty().getKorean(),
+                    quiz.getDifficulty() != null ? quiz.getDifficulty().getKorean() : null,
                     result.getScore(),
                     total,
                     calculatedAccuracy


### PR DESCRIPTION
## 🔍 관련 이슈
- close #81 

<br>

## ✅ 작업 분류
- [ ] 신규 기능
- [x] 기능 수정
- [ ] 버그 수정
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
<!--
  ex) 
  1. 네 발 짐승 클래스에 `크앙` 함수 추가
  2. 고양이 클래스에서 `크앙` 함수에 `미야아옹.wav` 재생시킴
-->
- 퀴즈 사용자 생성 시 difficulty 값 중으로 설정

<br>

## 👥 전달사항
<!--
1. User 도메인 구조를 변경하였습니다.
2. User 도메인 사용자 닉네임 필드를 username -> nickname으로 변경하였습니다.
-->

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
