### PR TITLE
🐛Bug: 홈화면 조회 시 쿼리 중복 결과 해결

### DIFF
--- a/src/main/java/com/likelion/server/domain/user/service/UserServiceImpl.java
+++ b/src/main/java/com/likelion/server/domain/user/service/UserServiceImpl.java
@@ -148,10 +148,12 @@ public class UserServiceImpl implements UserService {
             if (qaBoardOpt.isPresent()) {
                 QaBoard qaBoard = qaBoardOpt.get();
 
-                // 퀴즈에 대한 점수(QuizResult) 조회
+                // 퀴즈에 대한 점수(QuizResult) 조회 (DB 호출 1번)
                 Optional<QuizResult> resultOpt = quizResultRepository.findByUserAndQuiz(user, quiz);
 
-                String progress = calculateProgress(user, quiz);
+                // !--- 수정된 부분 ---!
+                // calculateProgress 메서드에 이미 조회한 resultOpt를 넘겨줍니다.
+                String progress = calculateProgress(quiz, resultOpt);
 
                 qaBoardDtos.add(new HomeResponse.QaBoardDto(qaBoard, progress));
             }
@@ -258,9 +260,9 @@ public class UserServiceImpl implements UserService {
     }
 
     // progress 계산 메서드
-    private String calculateProgress(User user, Quiz quiz) {
+    private String calculateProgress(Quiz quiz, Optional<QuizResult> resultOpt) {
         // 퀴즈에 대한 점수(QuizResult) 조회
-        Optional<QuizResult> resultOpt = quizResultRepository.findByUserAndQuiz(user, quiz);
+        // Optional<QuizResult> resultOpt = quizResultRepository.findByUserAndQuiz(user, quiz);
 
         int total = (quiz.getTotalQuestions() != null) ? quiz.getTotalQuestions() : 0;
 


### PR DESCRIPTION
## 🔍 관련 이슈
<!--
- close #123
-->
- close #91 

<br>

## ✅ 작업 분류
- [ ] 신규 기능
- [ ] 기능 수정
- [x] 버그 수정
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
1. calculateProgress 메서드의 시그니처를 변경하여, Optional<QuizResult>를 파라미터로 직접 받도록 수정했습니다.
2. getHome 메서드에서 findByUserAndQuiz를 1회만 호출하고, 조회된 Optional<QuizResult>를 calculateProgress에 전달하도록 변경했습니다.

<br>

## 👥 전달사항
<!--
1. User 도메인 구조를 변경하였습니다.
2. User 도메인 사용자 닉네임 필드를 username -> nickname으로 변경하였습니다.
-->

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
