### PR TITLE
🚨 Fix: 유저 퀴즈 중복 결과 생성 방지 및 startQuiz 로직 수정

### DIFF
--- a/src/main/java/com/likelion/server/domain/quiz/repository/QuizResultRepository.java
+++ b/src/main/java/com/likelion/server/domain/quiz/repository/QuizResultRepository.java
@@ -20,6 +20,9 @@ public interface QuizResultRepository extends JpaRepository<QuizResult, Long> {
 
     Optional<QuizResult> findByUserAndQuizId(User user, Long quizId);
 
+    QuizResult findByUserIdAndQuizId(Long quizId, Long userId);
+
+
     List<QuizResult> findAllByUserAndQuizIn(User user, List<Quiz> quizzes);
 
     List<QuizResult> findAllByQuizIn(List<Quiz> quizzes);

--- a/src/main/java/com/likelion/server/domain/quiz/service/QuizResultService.java
+++ b/src/main/java/com/likelion/server/domain/quiz/service/QuizResultService.java
@@ -32,12 +32,21 @@ public class QuizResultService {
 
     public QuizResult startQuiz(Long userId, QuizResultRequest request) {
 
+        Long quizId = request.quiz_id();
+
         Quiz quiz = quizRepository.findById(request.quiz_id())
                 .orElseThrow(() -> new IllegalArgumentException("해당 퀴즈를 찾을 수 없습니다."));
 
         User user = em.getReference(User.class, userId);
         Group group = quiz.getGroup();
 
+        // 1) 이미 풀었는지 체크
+        QuizResult existing = quizResultRepository.findByUserIdAndQuizId(userId, quizId);
+        if (existing != null) {
+            return existing;
+        }
+
+        // 2) 처음 푸는 경우에만 생성
         QuizResult quizResult = request.toEntity(quiz, user, group);
 
         return quizResultRepository.save(quizResult);


### PR DESCRIPTION
## 🔍 관련 이슈
- close #93

<br>

## ✅ 작업 분류
- [ ] 신규 기능
- [x] 기능 수정
- [x] 버그 수정
- [ ] 프로젝트 구조 변경
- [ ] 코드 리팩토링
- [ ] 문서 작성

<br>

## ✨ 작업 내용
1. `startQuiz` 로직 수정
   - 동일 유저가 동일 퀴즈를 두 번 이상 시작할 경우 중복 `QuizResult`가 생성되지 않도록 기존 결과 반환하도록 변경
2. `QuizResultRepository`에 `findByUserIdAndQuizId` 조회 메서드 추가
3. DB UNIQUE 제약(`quiz_result.unique_quiz_user`) 충돌 문제 해결
4. 유저당 퀴즈 1회 풀이 정책 안전하게 적용

<br>

## 👥 전달사항
- 기존에 생성된 중복 `quiz_result` 데이터는 DB 단에서 처리 완료해야 하며, 이후부터는 중복 생성이 발생하지 않습니다.
- 이 로직으로 인해 유저는 같은 퀴즈를 여러 번 풀 수 없으며, 항상 기존 결과만 반환됩니다.

<br>

## ✅ 체크리스트
- [x] 코드가 컴파일 및 빌드됨
- [x] 모든 테스트가 통과함
- [x] 관련 문서가 업데이트됨
- [x] 코드 리뷰가 수행됨
- [x] 커밋 메시지를 확인함

<br>

## 📸 스크린샷
<!--포스트맨 테스트 스크린 샷을 업로드해주세요.-->
<img width="849" height="847" alt="image" src="https://github.com/user-attachments/assets/fa4af2fa-c055-4087-8234-00a6fc2314bd" />
